### PR TITLE
Add token refresh, error handling, and Git workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,16 @@
 @AGENTS.md
+
+## Git / GitHub ルール
+
+### コミット・push・PR 作成前の確認
+
+- `git push` を実行する前に、必ずユーザーに確認を取ること
+- PR を作成する前に、必ずユーザーに確認を取ること
+
+### ブランチ命名規則
+
+| ブランチ種別 | 命名規則 | 例 |
+|---|---|---|
+| 機能追加 | `feature/<対応名>` | `feature/add-task-filter` |
+| ドキュメント | `docs/<対応名>` | `docs/update-readme` |
+| バグ修正 | `fix/<対応名>` | `fix/timezone-issue` |

--- a/auth.ts
+++ b/auth.ts
@@ -23,10 +23,43 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         token.refreshToken = account.refresh_token;
         token.expiresAt = account.expires_at;
       }
-      return token;
+
+      // アクセストークンがまだ有効な場合はそのまま返す（60秒の余裕を持つ）
+      const expiresAt = token.expiresAt as number | undefined;
+      if (!expiresAt || Date.now() / 1000 < expiresAt - 60) {
+        return token;
+      }
+
+      // トークンが期限切れ → リフレッシュトークンで再取得
+      try {
+        const response = await fetch("https://oauth2.googleapis.com/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            client_id: process.env.GOOGLE_CLIENT_ID!,
+            client_secret: process.env.GOOGLE_CLIENT_SECRET!,
+            grant_type: "refresh_token",
+            refresh_token: token.refreshToken as string,
+          }),
+        });
+
+        const refreshed = await response.json();
+
+        if (!response.ok) throw refreshed;
+
+        return {
+          ...token,
+          accessToken: refreshed.access_token,
+          expiresAt: Math.floor(Date.now() / 1000) + refreshed.expires_in,
+        };
+      } catch (err) {
+        console.error("[auth] Token refresh failed:", err);
+        return { ...token, error: "RefreshTokenError" };
+      }
     },
     async session({ session, token }) {
       session.accessToken = token.accessToken as string;
+      session.error = token.error as string | undefined;
       return session;
     },
   },

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -4,6 +4,7 @@ import { google } from "googleapis";
 
 export async function GET() {
   const session = await auth();
+  console.log("[tasks] session accessToken:", session?.accessToken ? "present" : "missing");
 
   if (!session?.accessToken) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -63,9 +64,10 @@ export async function GET() {
 
     return NextResponse.json({ tasks: todayTasks });
   } catch (err) {
-    console.error("Google Tasks API error:", err);
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("Google Tasks API error:", message);
     return NextResponse.json(
-      { error: "Failed to fetch tasks" },
+      { error: "Failed to fetch tasks", detail: process.env.NODE_ENV === "development" ? message : undefined },
       { status: 500 }
     );
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,10 @@ export default function Home() {
     setError(null);
     try {
       const res = await fetch("/api/tasks");
-      if (!res.ok) throw new Error("タスクの取得に失敗しました");
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? "タスクの取得に失敗しました");
+      }
       const data = await res.json();
       setTasks(data.tasks);
     } catch (e) {
@@ -35,6 +38,10 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
+    if (session?.error === "RefreshTokenError") {
+      signIn("google");
+      return;
+    }
     if (session) {
       fetchTasks();
     }

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -3,5 +3,6 @@ import "next-auth";
 declare module "next-auth" {
   interface Session {
     accessToken?: string;
+    error?: string;
   }
 }


### PR DESCRIPTION
## Summary

- `auth.ts`: JWT callback に access_token の自動リフレッシュ処理を追加。トークン期限切れ時に refresh_token で再取得し、失敗時は `RefreshTokenError` をセット
- `page.tsx`: `RefreshTokenError` 検知時に自動で `signIn()` へリダイレクト
- `tasks/route.ts`: エラー詳細を開発環境限定で `detail` フィールドに返すよう改善（デバッグ効率向上）
- `next-auth.d.ts`: `Session` 型に `error` フィールドを追加
- `CLAUDE.md`: Git/GitHub 操作ルール（push・PR前の確認、ブランチ命名規則）を追記

## Test plan

- [ ] ログイン後、1時間以上経過した状態でタスク一覧を更新してもセッションが切れないことを確認
- [ ] access_token リフレッシュ失敗時（無効な refresh_token など）に自動でログイン画面にリダイレクトされることを確認
- [ ] タスク取得失敗時に開発環境でエラー詳細が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)