### PR TITLE
Add project-specific API_NOTES.md

### DIFF
--- a/API_NOTES.md
+++ b/API_NOTES.md
@@ -2,6 +2,57 @@
 
 ---
 
+## OAuth / 認証
+
+### access_token のリフレッシュ処理は必須
+
+**なぜ気づかなかったか:** 初回ログイン直後はトークンが有効なため、1時間後まで問題が表面化しなかった。
+**ルール:** NextAuth で Google OAuth を使う場合、JWT コールバックにリフレッシュ処理を必ずセットで実装する。
+
+```typescript
+// auth.ts — jwt コールバックのテンプレート
+async jwt({ token, account }) {
+  if (account) {
+    token.accessToken = account.access_token;
+    token.refreshToken = account.refresh_token;
+    token.expiresAt = account.expires_at;
+  }
+
+  // まだ有効なら返す（60秒の余裕）
+  const expiresAt = token.expiresAt as number | undefined;
+  if (!expiresAt || Date.now() / 1000 < expiresAt - 60) return token;
+
+  // 期限切れ → リフレッシュ
+  try {
+    const res = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: process.env.GOOGLE_CLIENT_ID!,
+        client_secret: process.env.GOOGLE_CLIENT_SECRET!,
+        grant_type: "refresh_token",
+        refresh_token: token.refreshToken as string,
+      }),
+    });
+    const refreshed = await res.json();
+    if (!res.ok) throw refreshed;
+    return {
+      ...token,
+      accessToken: refreshed.access_token,
+      expiresAt: Math.floor(Date.now() / 1000) + refreshed.expires_in,
+    };
+  } catch (err) {
+    console.error("[auth] Token refresh failed:", err);
+    return { ...token, error: "RefreshTokenError" };
+  }
+}
+```
+
+- refresh_token を取得するには `access_type: "offline"` + `prompt: "consent"` が必要
+- リフレッシュ失敗時は `error: "RefreshTokenError"` をセットし、クライアントで `signIn()` へリダイレクト
+
+---
+
 ## Google Tasks API v1
 
 ### 完了タスクの取得には `showCompleted` と `showHidden` の両方が必要
@@ -48,3 +99,27 @@ if (task.status === "completed" && task.completed) {
 ### Google Tasks API v1 は繰り返し情報を返さない
 
 `recurrence`・`repeat` フィールドは存在しない。`links` も空配列。Google Calendar UI の ↺ アイコンは Tasks API 経由では取得不可。
+
+---
+
+## NextAuth v5 (beta)
+
+- `AUTH_SECRET` 未設定だとセッションが null になる
+- `access_token` は `jwt` → `session` コールバック経由で `session.accessToken` に渡す
+- API Route でのセッション取得は `await auth()` を使う（`getServerSession` は v4 の書き方）
+
+---
+
+## Google Cloud Console セットアップ
+
+### API 有効化を忘れやすい
+
+Cloud Console でプロジェクトを作った後、使いたい API（Tasks, Calendar 等）を個別に有効化しないと 403 になる。
+→ セットアップ時に必ず確認する。
+
+### Google OAuth セットアップチェックリスト
+
+- [ ] Google Cloud Console で対象 API を有効化
+- [ ] OAuth 同意画面でテストユーザーに自分のメールを追加（未審査アプリは必須）
+- [ ] リダイレクト URI に `http://localhost:3000/api/auth/callback/google` を追加
+- [ ] `.env.local` に `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `AUTH_SECRET` を設定


### PR DESCRIPTION
## Summary
- Google Tasks API・OAuth・NextAuth のノウハウを `API_NOTES.md` としてプロジェクト固有で管理
- common リポジトリから移動した内容（access_token リフレッシュ・OAuth セットアップ手順）を統合
- 今回新たに判明した知見（showHidden必須・completedフィールドの扱い）を追記

## Test plan
- [ ] `API_NOTES.md` がプロジェクトルートに存在することを確認
- [ ] OAuth/NextAuth/Google Tasks API の各セクションが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)