### PR TITLE
Add Claude Code GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,22 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Claude Code GitHub Actions ワークフロー (`.github/workflows/claude.yml`) を追加
- Issue・IssueコメントでClaude Codeを呼び出せるようになる
- `@claude` メンションで動作

## Test plan
- [ ] `ANTHROPIC_API_KEY` シークレットがリポジトリに設定済みであること確認
- [ ] Issue を作成し本文に `@claude` を含めて動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)