### PR TITLE
fix: GitHub Actions に id-token: write 権限を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,6 +16,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
## Summary
- `claude-code-action@beta` が OIDC トークンを必要とするため `id-token: write` を追加

## Test plan
- [ ] Issue にコメントで `@claude` を含む指示を書き、Actions が正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)