### PR TITLE
fix: claude-code-actionの前にactions/checkoutを追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## 関連仕様Issue
- Closes #14

## Summary
- `actions/checkout@v4` を `claude-code-action@beta` の前に追加
- これがないと git リポジトリが存在せず `fatal: not a git repository` エラーで失敗していた

## Test plan
- [ ] Issue #14 に `@claude` コメントを投稿し、GitHub Actions が正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)