### PR TITLE
fix: anthropic_api_key を claude_code_oauth_token に変更

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- `anthropic_api_key` を `claude_code_oauth_token` に変更し、Claude Max プランの OAuth トークンを使用するよう修正

## Test plan
- [ ] マージ後、Issue に `@claude` でメンションしてワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)