### PR TITLE
feat: 期限切れタスク表示機能を追加

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "auth";
 import { google } from "googleapis";
-import { fetchTodayTasks } from "@/lib/tasks";
+import { fetchTodayTasks, fetchExpiredTasks } from "@/lib/tasks";
 
 export async function GET() {
   const session = await auth();
@@ -11,8 +11,11 @@ export async function GET() {
   }
 
   try {
-    const tasks = await fetchTodayTasks(session.accessToken as string);
-    return NextResponse.json({ tasks });
+    const [todayTasks, expiredTasks] = await Promise.all([
+      fetchTodayTasks(session.accessToken as string),
+      fetchExpiredTasks(session.accessToken as string),
+    ]);
+    return NextResponse.json({ todayTasks, expiredTasks });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("Google Tasks API error:", message);

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -6,11 +6,13 @@ import type { Task } from "@/lib/tasks";
 
 type Props = {
   initialTasks: Task[];
+  initialExpiredTasks: Task[];
   initialCompletedTasks?: Task[];
 };
 
-export default function TaskList({ initialTasks, initialCompletedTasks }: Props) {
+export default function TaskList({ initialTasks, initialExpiredTasks, initialCompletedTasks }: Props) {
   const [incompleteTasks, setIncompleteTasks] = useState<Task[]>(initialTasks);
+  const [expiredTasks, setExpiredTasks] = useState<Task[]>(initialExpiredTasks);
   const [completedTasks, setCompletedTasks] = useState<Task[]>(initialCompletedTasks ?? []);
   const [loading, setLoading] = useState(false);
   const [completing, setCompleting] = useState<Set<string>>(new Set());
@@ -27,7 +29,8 @@ export default function TaskList({ initialTasks, initialCompletedTasks }: Props)
         throw new Error(body.detail ?? "タスクの取得に失敗しました");
       }
       const data = await res.json();
-      setIncompleteTasks(data.tasks);
+      setIncompleteTasks(data.todayTasks);
+      setExpiredTasks(data.expiredTasks);
     } catch (e) {
       setError(e instanceof Error ? e.message : "エラーが発生しました");
     } finally {
@@ -51,6 +54,7 @@ export default function TaskList({ initialTasks, initialCompletedTasks }: Props)
         return next;
       });
       setIncompleteTasks((prev) => prev.filter((t) => t.id !== task.id));
+      setExpiredTasks((prev) => prev.filter((t) => t.id !== task.id));
       setCompletedTasks((prev) => [task, ...prev]);
       setNewlyCompleted((prev) => new Set(prev).add(task.id));
 
@@ -70,12 +74,18 @@ export default function TaskList({ initialTasks, initialCompletedTasks }: Props)
       const syncRes = await fetch("/api/tasks");
       if (syncRes.ok) {
         const data = await syncRes.json();
-        setIncompleteTasks(data.tasks);
+        setIncompleteTasks(data.todayTasks);
+        setExpiredTasks(data.expiredTasks);
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "エラーが発生しました");
       setCompletedTasks((prev) => prev.filter((t) => t.id !== task.id));
-      setIncompleteTasks((prev) => [task, ...prev]);
+      const isExpired = new Date(task.due).toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" }) < new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+      if (isExpired) {
+        setExpiredTasks((prev) => [task, ...prev]);
+      } else {
+        setIncompleteTasks((prev) => [task, ...prev]);
+      }
     }
   };
 
@@ -119,10 +129,54 @@ export default function TaskList({ initialTasks, initialCompletedTasks }: Props)
           </div>
         )}
 
-        {loading && incompleteTasks.length === 0 && completedTasks.length === 0 ? (
+        {loading && incompleteTasks.length === 0 && expiredTasks.length === 0 && completedTasks.length === 0 ? (
           <div className="text-center py-16 text-gray-400">タスクを取得中...</div>
         ) : (
-          <div className="flex flex-col md:flex-row gap-6">
+          <div className="flex flex-col lg:flex-row gap-6">
+            {/* 期限切れカラム */}
+            <div className="flex-1">
+              <h2 className="text-sm font-semibold text-red-600 uppercase tracking-wide mb-3">
+                期限切れ{" "}
+                <span className="font-normal text-red-400">
+                  ({expiredTasks.length}件)
+                </span>
+              </h2>
+              {expiredTasks.length === 0 ? (
+                <div className="text-center py-12 text-gray-300 text-sm border-2 border-dashed border-gray-200 rounded-lg">
+                  期限切れタスクがここに表示されます
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {expiredTasks.map((task) => (
+                    <div
+                      key={task.id}
+                      className="flex items-start gap-3 bg-red-50 border border-red-200 rounded-lg px-4 py-3 shadow-sm"
+                      style={
+                        completing.has(task.id)
+                          ? { animation: "fadeOut 300ms forwards" }
+                          : undefined
+                      }
+                    >
+                      <button
+                        onClick={() => completeTask(task)}
+                        disabled={completing.has(task.id)}
+                        className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-red-300 hover:border-green-500 hover:bg-green-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        aria-label="完了にする"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-red-800 font-medium leading-snug">
+                          {task.title}
+                        </p>
+                        <span className="inline-block mt-1 text-xs text-red-500 bg-red-100 rounded px-2 py-0.5">
+                          {task.listTitle}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
             {/* 未完了カラム */}
             <div className="flex-1">
               <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
@@ -131,7 +185,7 @@ export default function TaskList({ initialTasks, initialCompletedTasks }: Props)
                   ({incompleteTasks.length}件)
                 </span>
               </h2>
-              {incompleteTasks.length === 0 && completedTasks.length === 0 ? (
+              {incompleteTasks.length === 0 && expiredTasks.length === 0 && completedTasks.length === 0 ? (
                 <div className="text-center py-12">
                   <div className="text-4xl mb-3">🎉</div>
                   <p className="text-gray-500">今日期限のタスクはありません</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { auth } from "auth";
 import { redirect } from "next/navigation";
-import { fetchTodayTasks, fetchTodayCompletedTasks } from "@/lib/tasks";
+import { fetchTodayTasks, fetchExpiredTasks, fetchTodayCompletedTasks } from "@/lib/tasks";
 import TaskList from "@/app/components/TaskList";
 import LoginButton from "@/app/components/LoginButton";
 
@@ -17,10 +17,11 @@ export default async function Home() {
     redirect("/api/auth/signin?provider=google");
   }
 
-  const [tasks, completedTasks] = await Promise.all([
+  const [tasks, expiredTasks, completedTasks] = await Promise.all([
     fetchTodayTasks(session.accessToken as string),
+    fetchExpiredTasks(session.accessToken as string),
     fetchTodayCompletedTasks(session.accessToken as string),
   ]);
 
-  return <TaskList initialTasks={tasks} initialCompletedTasks={completedTasks} />;
+  return <TaskList initialTasks={tasks} initialExpiredTasks={expiredTasks} initialCompletedTasks={completedTasks} />;
 }

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -52,6 +52,49 @@ export async function fetchTodayTasks(accessToken: string): Promise<Task[]> {
   return todayTasks;
 }
 
+export async function fetchExpiredTasks(accessToken: string): Promise<Task[]> {
+  const oauth2Client = new google.auth.OAuth2();
+  oauth2Client.setCredentials({ access_token: accessToken });
+
+  const tasksApi = google.tasks({ version: "v1", auth: oauth2Client });
+
+  const listsRes = await tasksApi.tasklists.list({ maxResults: 100 });
+  const lists = listsRes.data.items ?? [];
+
+  const todayStr = new Date().toLocaleDateString("sv-SE", {
+    timeZone: "Asia/Tokyo",
+  });
+
+  const allTasksResults = await Promise.all(
+    lists.map((list) =>
+      tasksApi.tasks
+        .list({ tasklist: list.id!, maxResults: 100, showCompleted: false })
+        .then((res) => ({ list, items: res.data.items ?? [] }))
+    )
+  );
+
+  const expiredTasks: Task[] = [];
+  for (const { list, items } of allTasksResults) {
+    for (const task of items) {
+      if (task.due) {
+        const taskDate = task.due.slice(0, 10);
+        if (taskDate < todayStr) {
+          expiredTasks.push({
+            id: task.id!,
+            title: task.title ?? "(タイトルなし)",
+            due: task.due,
+            status: task.status ?? "needsAction",
+            listId: list.id!,
+            listTitle: list.title ?? "(リストなし)",
+          });
+        }
+      }
+    }
+  }
+
+  return expiredTasks;
+}
+
 export async function fetchTodayCompletedTasks(accessToken: string): Promise<Task[]> {
   const oauth2Client = new google.auth.OAuth2();
   oauth2Client.setCredentials({ access_token: accessToken });


### PR DESCRIPTION
Issue #14 の内容に基づいて、期限切れタスク表示機能を実装しました。

## 実装内容
- 期限切れタスクを取得する`fetchExpiredTasks`関数を追加
- APIエンドポイントを更新し、期限切れタスクも返すように変更
- TaskListを三カラムレイアウトに変更（期限切れ・未完了・完了）
- 期限切れタスクは赤色のテーマで表示
- 期限切れタスクも完了ボタンで完了にできるように実装

Closes #14

Generated with [Claude Code](https://claude.ai/code)