### PR TITLE
fix: fetchTasks で expiredTasks が undefined になるクラッシュを修正

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -29,8 +29,8 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         throw new Error(body.detail ?? "タスクの取得に失敗しました");
       }
       const data = await res.json();
-      setIncompleteTasks(data.todayTasks);
-      setExpiredTasks(data.expiredTasks);
+      setIncompleteTasks(data.todayTasks ?? []);
+      setExpiredTasks(data.expiredTasks ?? []);
     } catch (e) {
       setError(e instanceof Error ? e.message : "エラーが発生しました");
     } finally {


### PR DESCRIPTION
## 関連仕様Issue
- Closes #

## 実装内容
`/api/tasks` のレスポンスに `expiredTasks` が含まれない場合、state が `undefined` になり `TypeError: Cannot read properties of undefined (reading 'length')` が発生していた。`setIncompleteTasks` / `setExpiredTasks` の両方に `?? []` フォールバックを追加して修正。

## 変更ファイル
- `src/app/components/TaskList.tsx` — fetchTasks 内の setState に `?? []` フォールバックを追加

## テスト手順
- [ ] タスク一覧画面を開き、更新ボタンを押しても TypeError が発生しないことを確認
- [ ] 期限切れタスクが正常に表示されることを確認

## 備考
なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)