### PR TITLE
Restrict @claude action to repo owner only

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,3 +22,4 @@ jobs:
       - uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_users: "argama147"


### PR DESCRIPTION
## 関連仕様Issue
<!-- 実装の元となった仕様IssueへのリンクをCloses #xxx で記載 -->
- なし（セキュリティ対応）

## 実装内容
`allowed_users: "argama147"` を追加し、リポジトリオーナー以外が @claude をトリガーできないよう制限。リポジトリ公開前のセキュリティ強化。

## 変更ファイル
- `.github/workflows/claude.yml` — `allowed_users` パラメータを追加

## テスト手順
- [ ] 自分のコメントで @claude が反応することを確認
- [ ] 他ユーザーのコメントでは反応しないことを確認（任意）

## 備考
なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)