### PR TITLE
Auto-close issues/PRs created by non-owners

### DIFF
--- a/.github/workflows/restrict-contributions.yml
+++ b/.github/workflows/restrict-contributions.yml
@@ -1,0 +1,32 @@
+name: Restrict Contributions
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  close-if-not-owner:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Close issue if not owner
+        if: github.event_name == 'issues' && github.event.issue.user.login != 'argama147'
+        run: |
+          gh issue close ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --comment "このリポジトリはオーナーのみ Issue を作成できます。コメントは歓迎します。"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Close PR if not owner
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'argama147'
+        run: |
+          gh pr close ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --comment "このリポジトリはオーナーのみ Pull Request を作成できます。"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 関連仕様Issue
- なし（リポジトリ公開対応）

## 実装内容
オーナー（argama147）以外が Issue / PR を作成した場合に自動クローズするワークフローを追加。コメントは引き続き誰でも可能。

## 変更ファイル
- `.github/workflows/restrict-contributions.yml` — 新規追加

## テスト手順
- [ ] 別アカウントで Issue を作成し、自動クローズされることを確認
- [ ] 自分のアカウントで Issue を作成し、クローズされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)