### PR TITLE
期限切れタスクで日付と期限を両方表示

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -238,7 +238,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                             {task.listTitle}
                           </span>
                           <span className="text-xs text-red-600 bg-red-200 rounded px-2 py-0.5 font-medium">
-                            期限: {new Date(task.due).toLocaleDateString("ja-JP", { timeZone: "Asia/Tokyo" })}
+                            {new Date(task.due).toLocaleDateString("ja-JP", { timeZone: "Asia/Tokyo" })}
                             ({(() => {
                               const today = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
                               const taskDate = task.due.slice(0, 10);
@@ -246,6 +246,9 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                               const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
                               return `${diffDays}日経過`;
                             })()})
+                          </span>
+                          <span className="text-xs text-red-600 bg-red-200 rounded px-2 py-0.5 font-medium">
+                            期限: {new Date(task.due).toLocaleDateString("ja-JP", { timeZone: "Asia/Tokyo" })}
                           </span>
                         </div>
                       </div>


### PR DESCRIPTION
## 概要

期限切れタスクリストにおいて、「日付」と「期限」を両方表示するように変更しました。

## 変更内容

- 日付は「期限:」なしで表示（経過日数付き）
- 期限は「期限:」付きで表示
- 期限切れタスクリストにおける表示の明確化

## 変更ファイル

- `src/app/components/TaskList.tsx`: 期限切れタスクの表示ロジックを修正

Closes #35

🤖 Generated with [Claude Code](https://claude.ai/code)