### PR TITLE
fix: explicitly set AUTH_SECRET in NextAuth config

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  secret: process.env.AUTH_SECRET,
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,


### PR DESCRIPTION
## 関連仕様Issue
なし（バグ修正）

## 実装内容
NextAuth v5 が環境変数 `AUTH_SECRET` を自動読み込みしない場合に備え、`auth.ts` に `secret: process.env.AUTH_SECRET` を明示的に追加。

## テスト手順
- [ ] Vercel デプロイ後、`https://daily-todo-management.vercel.app` でログインできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)