### PR TITLE
feat: 未来の期限タスクリストを追加

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -9,19 +9,31 @@ type Props = {
   initialTasks: Task[];
   initialExpiredTasks: Task[];
   initialCompletedTasks?: Task[];
+  initialFutureTasks?: {
+    withinWeek: Task[];
+    withinMonth: Task[];
+    longTerm: Task[];
+    noDeadline: Task[];
+  };
   user?: User;
 };
 
-export default function TaskList({ initialTasks, initialExpiredTasks, initialCompletedTasks, user }: Props) {
+export default function TaskList({ initialTasks, initialExpiredTasks, initialCompletedTasks, initialFutureTasks, user }: Props) {
   const [incompleteTasks, setIncompleteTasks] = useState<Task[]>(initialTasks);
   const [expiredTasks, setExpiredTasks] = useState<Task[]>(initialExpiredTasks);
   const [completedTasks, setCompletedTasks] = useState<Task[]>(initialCompletedTasks ?? []);
+  const [futureTasks, setFutureTasks] = useState<{
+    withinWeek: Task[];
+    withinMonth: Task[];
+    longTerm: Task[];
+    noDeadline: Task[];
+  }>(initialFutureTasks ?? { withinWeek: [], withinMonth: [], longTerm: [], noDeadline: [] });
   const [loading, setLoading] = useState(false);
   const [completing, setCompleting] = useState<Set<string>>(new Set());
   const [uncompleting, setUncompleting] = useState<Set<string>>(new Set());
   const [newlyCompleted, setNewlyCompleted] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
-  type TabKey = "expired" | "today" | "completed";
+  type TabKey = "expired" | "today" | "completed" | "withinWeek" | "withinMonth" | "longTerm" | "noDeadline";
   const [activeTab, setActiveTab] = useState<TabKey>("today");
   const [changingDue, setChangingDue] = useState<Set<string>>(new Set());
   const [showDatePicker, setShowDatePicker] = useState<string | null>(null);
@@ -230,16 +242,20 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         ) : (
           <>
             {/* モバイルのみ: タブ */}
-            <div className="flex lg:hidden border-b border-gray-200 mb-4">
+            <div className="flex lg:hidden border-b border-gray-200 mb-4 overflow-x-auto">
               {[
                 { key: "expired" as TabKey, label: "期限切れ", count: expiredTasks.length },
                 { key: "today" as TabKey, label: "本日", count: incompleteTasks.length },
                 { key: "completed" as TabKey, label: "完了", count: completedTasks.length },
+                { key: "withinWeek" as TabKey, label: "一週間", count: futureTasks.withinWeek.length },
+                { key: "withinMonth" as TabKey, label: "一ヶ月", count: futureTasks.withinMonth.length },
+                { key: "longTerm" as TabKey, label: "長期", count: futureTasks.longTerm.length },
+                { key: "noDeadline" as TabKey, label: "期限なし", count: futureTasks.noDeadline.length },
               ].map((tab) => (
                 <button
                   key={tab.key}
                   onClick={() => setActiveTab(tab.key)}
-                  className={`flex-1 py-2 text-sm font-medium border-b-2 transition-colors ${
+                  className={`flex-shrink-0 px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
                     activeTab === tab.key
                       ? "border-blue-500 text-blue-600"
                       : "border-transparent text-gray-500"
@@ -383,12 +399,151 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                   )}
                 </div>
               )}
+              {activeTab === "withinWeek" && (
+                <div>
+                  <h2 className="text-sm font-semibold text-blue-600 uppercase tracking-wide mb-3">
+                    一週間以内のタスク <span className="font-normal text-blue-400">({futureTasks.withinWeek.length}件)</span>
+                  </h2>
+                  {futureTasks.withinWeek.length === 0 ? (
+                    <div className="text-center py-12 text-gray-300 text-sm border-2 border-dashed border-gray-200 rounded-lg">一週間以内のタスクがここに表示されます</div>
+                  ) : (
+                    <div className="space-y-2">
+                      {futureTasks.withinWeek.map((task) => (
+                        <div key={task.id} className="flex items-start gap-3 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 shadow-sm" style={completing.has(task.id) ? { animation: "fadeOut 300ms forwards" } : undefined}>
+                          <button onClick={() => completeTask(task)} disabled={completing.has(task.id)} className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-blue-300 hover:border-green-500 hover:bg-green-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" aria-label="完了にする" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-blue-800 font-medium leading-snug">{task.title}</p>
+                            <div className="mt-1 flex flex-wrap gap-1">
+                              <span className="text-xs text-blue-500 bg-blue-100 rounded px-2 py-0.5">{task.listTitle}</span>
+                              <span className="text-xs text-blue-600 bg-blue-200 rounded px-2 py-0.5 font-medium">
+                                期限: {new Date(task.due).toLocaleDateString("ja-JP", { timeZone: "Asia/Tokyo" })}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="flex-shrink-0 ml-2">
+                            {showDatePicker === task.id ? (
+                              <input type="date" defaultValue={task.due.slice(0, 10)} onChange={(e) => changeDueDate(task, e.target.value + "T00:00:00.000Z")} onBlur={() => setShowDatePicker(null)} className="text-xs p-1 border rounded" autoFocus />
+                            ) : (
+                              <button onClick={() => setShowDatePicker(task.id)} disabled={changingDue.has(task.id)} className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:cursor-not-allowed">
+                                {changingDue.has(task.id) ? "変更中..." : "期限変更"}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+              {activeTab === "withinMonth" && (
+                <div>
+                  <h2 className="text-sm font-semibold text-orange-600 uppercase tracking-wide mb-3">
+                    一ヶ月以内のタスク <span className="font-normal text-orange-400">({futureTasks.withinMonth.length}件)</span>
+                  </h2>
+                  {futureTasks.withinMonth.length === 0 ? (
+                    <div className="text-center py-12 text-gray-300 text-sm border-2 border-dashed border-gray-200 rounded-lg">一ヶ月以内のタスクがここに表示されます</div>
+                  ) : (
+                    <div className="space-y-2">
+                      {futureTasks.withinMonth.map((task) => (
+                        <div key={task.id} className="flex items-start gap-3 bg-orange-50 border border-orange-200 rounded-lg px-4 py-3 shadow-sm" style={completing.has(task.id) ? { animation: "fadeOut 300ms forwards" } : undefined}>
+                          <button onClick={() => completeTask(task)} disabled={completing.has(task.id)} className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-orange-300 hover:border-green-500 hover:bg-green-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" aria-label="完了にする" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-orange-800 font-medium leading-snug">{task.title}</p>
+                            <div className="mt-1 flex flex-wrap gap-1">
+                              <span className="text-xs text-orange-500 bg-orange-100 rounded px-2 py-0.5">{task.listTitle}</span>
+                              <span className="text-xs text-orange-600 bg-orange-200 rounded px-2 py-0.5 font-medium">
+                                期限: {new Date(task.due).toLocaleDateString("ja-JP", { timeZone: "Asia/Tokyo" })}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="flex-shrink-0 ml-2">
+                            {showDatePicker === task.id ? (
+                              <input type="date" defaultValue={task.due.slice(0, 10)} onChange={(e) => changeDueDate(task, e.target.value + "T00:00:00.000Z")} onBlur={() => setShowDatePicker(null)} className="text-xs p-1 border rounded" autoFocus />
+                            ) : (
+                              <button onClick={() => setShowDatePicker(task.id)} disabled={changingDue.has(task.id)} className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:cursor-not-allowed">
+                                {changingDue.has(task.id) ? "変更中..." : "期限変更"}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+              {activeTab === "longTerm" && (
+                <div>
+                  <h2 className="text-sm font-semibold text-purple-600 uppercase tracking-wide mb-3">
+                    長期タスク <span className="font-normal text-purple-400">({futureTasks.longTerm.length}件)</span>
+                  </h2>
+                  {futureTasks.longTerm.length === 0 ? (
+                    <div className="text-center py-12 text-gray-300 text-sm border-2 border-dashed border-gray-200 rounded-lg">長期タスクがここに表示されます</div>
+                  ) : (
+                    <div className="space-y-2">
+                      {futureTasks.longTerm.map((task) => (
+                        <div key={task.id} className="flex items-start gap-3 bg-purple-50 border border-purple-200 rounded-lg px-4 py-3 shadow-sm" style={completing.has(task.id) ? { animation: "fadeOut 300ms forwards" } : undefined}>
+                          <button onClick={() => completeTask(task)} disabled={completing.has(task.id)} className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-purple-300 hover:border-green-500 hover:bg-green-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" aria-label="完了にする" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-purple-800 font-medium leading-snug">{task.title}</p>
+                            <div className="mt-1 flex flex-wrap gap-1">
+                              <span className="text-xs text-purple-500 bg-purple-100 rounded px-2 py-0.5">{task.listTitle}</span>
+                              <span className="text-xs text-purple-600 bg-purple-200 rounded px-2 py-0.5 font-medium">
+                                期限: {new Date(task.due).toLocaleDateString("ja-JP", { timeZone: "Asia/Tokyo" })}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="flex-shrink-0 ml-2">
+                            {showDatePicker === task.id ? (
+                              <input type="date" defaultValue={task.due.slice(0, 10)} onChange={(e) => changeDueDate(task, e.target.value + "T00:00:00.000Z")} onBlur={() => setShowDatePicker(null)} className="text-xs p-1 border rounded" autoFocus />
+                            ) : (
+                              <button onClick={() => setShowDatePicker(task.id)} disabled={changingDue.has(task.id)} className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:cursor-not-allowed">
+                                {changingDue.has(task.id) ? "変更中..." : "期限変更"}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+              {activeTab === "noDeadline" && (
+                <div>
+                  <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">
+                    期限なしタスク <span className="font-normal text-gray-400">({futureTasks.noDeadline.length}件)</span>
+                  </h2>
+                  {futureTasks.noDeadline.length === 0 ? (
+                    <div className="text-center py-12 text-gray-300 text-sm border-2 border-dashed border-gray-200 rounded-lg">期限なしのタスクがここに表示されます</div>
+                  ) : (
+                    <div className="space-y-2">
+                      {futureTasks.noDeadline.map((task) => (
+                        <div key={task.id} className="flex items-start gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 shadow-sm" style={completing.has(task.id) ? { animation: "fadeOut 300ms forwards" } : undefined}>
+                          <button onClick={() => completeTask(task)} disabled={completing.has(task.id)} className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-300 hover:border-green-500 hover:bg-green-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" aria-label="完了にする" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-gray-800 font-medium leading-snug">{task.title}</p>
+                            <span className="inline-block mt-1 text-xs text-gray-400 bg-gray-100 rounded px-2 py-0.5">{task.listTitle}</span>
+                          </div>
+                          <div className="flex-shrink-0 ml-2">
+                            {showDatePicker === task.id ? (
+                              <input type="date" defaultValue={new Date().toISOString().split('T')[0]} onChange={(e) => changeDueDate(task, e.target.value + "T00:00:00.000Z")} onBlur={() => setShowDatePicker(null)} className="text-xs p-1 border rounded" autoFocus />
+                            ) : (
+                              <button onClick={() => setShowDatePicker(task.id)} disabled={changingDue.has(task.id)} className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:cursor-not-allowed">
+                                {changingDue.has(task.id) ? "変更中..." : "期限変更"}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
-            {/* デスクトップ: 3カラム並列 */}
-            <div className="hidden lg:flex flex-row gap-6">
+            {/* デスクトップ: 7カラム並列 */}
+            <div className="hidden lg:grid grid-cols-7 gap-4">
               {/* 期限切れカラム */}
-              <div className="flex-1">
+              <div>
                 <h2 className="text-sm font-semibold text-red-600 uppercase tracking-wide mb-3">
                   期限切れタスク{" "}
                   <span className="font-normal text-red-400">
@@ -464,7 +619,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
               </div>
 
               {/* 未完了カラム */}
-              <div className="flex-1">
+              <div>
                 <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
                   本日の未完了タスク{" "}
                   <span className="font-normal text-gray-400">
@@ -533,7 +688,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
               </div>
 
               {/* 完了カラム */}
-              <div className="flex-1">
+              <div>
                 <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
                   完了したタスク{" "}
                   <span className="font-normal text-gray-400">
@@ -585,6 +740,277 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                           <span className="inline-block mt-1 text-xs text-gray-400 bg-green-100 rounded px-2 py-0.5">
                             {task.listTitle}
                           </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* 一週間以内カラム */}
+              <div>
+                <h2 className="text-sm font-semibold text-blue-600 uppercase tracking-wide mb-3">
+                  一週間以内{" "}
+                  <span className="font-normal text-blue-400">
+                    ({futureTasks.withinWeek.length}件)
+                  </span>
+                </h2>
+                {futureTasks.withinWeek.length === 0 ? (
+                  <div className="text-center py-12 text-gray-300 text-sm border-2 border-dashed border-gray-200 rounded-lg">
+                    一週間以内のタスクがここに表示されます
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {futureTasks.withinWeek.map((task) => (
+                      <div
+                        key={task.id}
+                        className="flex items-start gap-3 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 shadow-sm"
+                        style={
+                          completing.has(task.id)
+                            ? { animation: "fadeOut 300ms forwards" }
+                            : undefined
+                        }
+                      >
+                        <button
+                          onClick={() => completeTask(task)}
+                          disabled={completing.has(task.id)}
+                          className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-blue-300 hover:border-green-500 hover:bg-green-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          aria-label="完了にする"
+                        />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-blue-800 font-medium leading-snug text-sm">
+                            {task.title}
+                          </p>
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            <span className="text-xs text-blue-500 bg-blue-100 rounded px-2 py-0.5">
+                              {task.listTitle}
+                            </span>
+                            <span className="text-xs text-blue-600 bg-blue-200 rounded px-2 py-0.5 font-medium">
+                              {new Date(task.due).toLocaleDateString("ja-JP", { timeZone: "Asia/Tokyo" })}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex-shrink-0 ml-2">
+                          {showDatePicker === task.id ? (
+                            <input
+                              type="date"
+                              defaultValue={task.due.slice(0, 10)}
+                              onChange={(e) => changeDueDate(task, e.target.value + "T00:00:00.000Z")}
+                              onBlur={() => setShowDatePicker(null)}
+                              className="text-xs p-1 border rounded"
+                              autoFocus
+                            />
+                          ) : (
+                            <button
+                              onClick={() => setShowDatePicker(task.id)}
+                              disabled={changingDue.has(task.id)}
+                              className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              {changingDue.has(task.id) ? "変更中..." : "期限変更"}
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* 一ヶ月以内カラム */}
+              <div>
+                <h2 className="text-sm font-semibold text-orange-600 uppercase tracking-wide mb-3">
+                  一ヶ月以内{" "}
+                  <span className="font-normal text-orange-400">
+                    ({futureTasks.withinMonth.length}件)
+                  </span>
+                </h2>
+                {futureTasks.withinMonth.length === 0 ? (
+                  <div className="text-center py-12 text-gray-300 text-sm border-2 border-dashed border-gray-200 rounded-lg">
+                    一ヶ月以内のタスクがここに表示されます
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {futureTasks.withinMonth.map((task) => (
+                      <div
+                        key={task.id}
+                        className="flex items-start gap-3 bg-orange-50 border border-orange-200 rounded-lg px-4 py-3 shadow-sm"
+                        style={
+                          completing.has(task.id)
+                            ? { animation: "fadeOut 300ms forwards" }
+                            : undefined
+                        }
+                      >
+                        <button
+                          onClick={() => completeTask(task)}
+                          disabled={completing.has(task.id)}
+                          className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-orange-300 hover:border-green-500 hover:bg-green-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          aria-label="完了にする"
+                        />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-orange-800 font-medium leading-snug text-sm">
+                            {task.title}
+                          </p>
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            <span className="text-xs text-orange-500 bg-orange-100 rounded px-2 py-0.5">
+                              {task.listTitle}
+                            </span>
+                            <span className="text-xs text-orange-600 bg-orange-200 rounded px-2 py-0.5 font-medium">
+                              {new Date(task.due).toLocaleDateString("ja-JP", { timeZone: "Asia/Tokyo" })}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex-shrink-0 ml-2">
+                          {showDatePicker === task.id ? (
+                            <input
+                              type="date"
+                              defaultValue={task.due.slice(0, 10)}
+                              onChange={(e) => changeDueDate(task, e.target.value + "T00:00:00.000Z")}
+                              onBlur={() => setShowDatePicker(null)}
+                              className="text-xs p-1 border rounded"
+                              autoFocus
+                            />
+                          ) : (
+                            <button
+                              onClick={() => setShowDatePicker(task.id)}
+                              disabled={changingDue.has(task.id)}
+                              className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              {changingDue.has(task.id) ? "変更中..." : "期限変更"}
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* 長期カラム */}
+              <div>
+                <h2 className="text-sm font-semibold text-purple-600 uppercase tracking-wide mb-3">
+                  長期{" "}
+                  <span className="font-normal text-purple-400">
+                    ({futureTasks.longTerm.length}件)
+                  </span>
+                </h2>
+                {futureTasks.longTerm.length === 0 ? (
+                  <div className="text-center py-12 text-gray-300 text-sm border-2 border-dashed border-gray-200 rounded-lg">
+                    長期タスクがここに表示されます
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {futureTasks.longTerm.map((task) => (
+                      <div
+                        key={task.id}
+                        className="flex items-start gap-3 bg-purple-50 border border-purple-200 rounded-lg px-4 py-3 shadow-sm"
+                        style={
+                          completing.has(task.id)
+                            ? { animation: "fadeOut 300ms forwards" }
+                            : undefined
+                        }
+                      >
+                        <button
+                          onClick={() => completeTask(task)}
+                          disabled={completing.has(task.id)}
+                          className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-purple-300 hover:border-green-500 hover:bg-green-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          aria-label="完了にする"
+                        />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-purple-800 font-medium leading-snug text-sm">
+                            {task.title}
+                          </p>
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            <span className="text-xs text-purple-500 bg-purple-100 rounded px-2 py-0.5">
+                              {task.listTitle}
+                            </span>
+                            <span className="text-xs text-purple-600 bg-purple-200 rounded px-2 py-0.5 font-medium">
+                              {new Date(task.due).toLocaleDateString("ja-JP", { timeZone: "Asia/Tokyo" })}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex-shrink-0 ml-2">
+                          {showDatePicker === task.id ? (
+                            <input
+                              type="date"
+                              defaultValue={task.due.slice(0, 10)}
+                              onChange={(e) => changeDueDate(task, e.target.value + "T00:00:00.000Z")}
+                              onBlur={() => setShowDatePicker(null)}
+                              className="text-xs p-1 border rounded"
+                              autoFocus
+                            />
+                          ) : (
+                            <button
+                              onClick={() => setShowDatePicker(task.id)}
+                              disabled={changingDue.has(task.id)}
+                              className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              {changingDue.has(task.id) ? "変更中..." : "期限変更"}
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* 期限なしカラム */}
+              <div>
+                <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">
+                  期限なし{" "}
+                  <span className="font-normal text-gray-400">
+                    ({futureTasks.noDeadline.length}件)
+                  </span>
+                </h2>
+                {futureTasks.noDeadline.length === 0 ? (
+                  <div className="text-center py-12 text-gray-300 text-sm border-2 border-dashed border-gray-200 rounded-lg">
+                    期限なしのタスクがここに表示されます
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {futureTasks.noDeadline.map((task) => (
+                      <div
+                        key={task.id}
+                        className="flex items-start gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 shadow-sm"
+                        style={
+                          completing.has(task.id)
+                            ? { animation: "fadeOut 300ms forwards" }
+                            : undefined
+                        }
+                      >
+                        <button
+                          onClick={() => completeTask(task)}
+                          disabled={completing.has(task.id)}
+                          className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-300 hover:border-green-500 hover:bg-green-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          aria-label="完了にする"
+                        />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-gray-800 font-medium leading-snug text-sm">
+                            {task.title}
+                          </p>
+                          <span className="inline-block mt-1 text-xs text-gray-400 bg-gray-100 rounded px-2 py-0.5">
+                            {task.listTitle}
+                          </span>
+                        </div>
+                        <div className="flex-shrink-0 ml-2">
+                          {showDatePicker === task.id ? (
+                            <input
+                              type="date"
+                              defaultValue={new Date().toISOString().split('T')[0]}
+                              onChange={(e) => changeDueDate(task, e.target.value + "T00:00:00.000Z")}
+                              onBlur={() => setShowDatePicker(null)}
+                              className="text-xs p-1 border rounded"
+                              autoFocus
+                            />
+                          ) : (
+                            <button
+                              onClick={() => setShowDatePicker(task.id)}
+                              disabled={changingDue.has(task.id)}
+                              className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              {changingDue.has(task.id) ? "変更中..." : "期限変更"}
+                            </button>
+                          )}
                         </div>
                       </div>
                     ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { auth } from "auth";
 import { redirect } from "next/navigation";
-import { fetchTodayTasks, fetchExpiredTasks, fetchTodayCompletedTasks } from "@/lib/tasks";
+import { fetchTodayTasks, fetchExpiredTasks, fetchTodayCompletedTasks, fetchFutureTasks } from "@/lib/tasks";
 import TaskList from "@/app/components/TaskList";
 import LoginButton from "@/app/components/LoginButton";
 
@@ -17,11 +17,12 @@ export default async function Home() {
     redirect("/api/auth/signin?provider=google");
   }
 
-  const [tasks, expiredTasks, completedTasks] = await Promise.all([
+  const [tasks, expiredTasks, completedTasks, futureTasks] = await Promise.all([
     fetchTodayTasks(session.accessToken as string),
     fetchExpiredTasks(session.accessToken as string),
     fetchTodayCompletedTasks(session.accessToken as string),
+    fetchFutureTasks(session.accessToken as string),
   ]);
 
-  return <TaskList initialTasks={tasks} initialExpiredTasks={expiredTasks} initialCompletedTasks={completedTasks} user={session.user} />;
+  return <TaskList initialTasks={tasks} initialExpiredTasks={expiredTasks} initialCompletedTasks={completedTasks} initialFutureTasks={futureTasks} user={session.user} />;
 }

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -95,6 +95,86 @@ export async function fetchExpiredTasks(accessToken: string): Promise<Task[]> {
   return expiredTasks;
 }
 
+export async function fetchFutureTasks(accessToken: string): Promise<{
+  withinWeek: Task[];
+  withinMonth: Task[];
+  longTerm: Task[];
+  noDeadline: Task[];
+}> {
+  const oauth2Client = new google.auth.OAuth2();
+  oauth2Client.setCredentials({ access_token: accessToken });
+
+  const tasksApi = google.tasks({ version: "v1", auth: oauth2Client });
+
+  const listsRes = await tasksApi.tasklists.list({ maxResults: 100 });
+  const lists = listsRes.data.items ?? [];
+
+  const allTasksResults = await Promise.all(
+    lists.map((list) =>
+      tasksApi.tasks
+        .list({ tasklist: list.id!, maxResults: 100, showCompleted: false })
+        .then((res) => ({ list, items: res.data.items ?? [] }))
+    )
+  );
+
+  const todayStr = new Date().toLocaleDateString("sv-SE", {
+    timeZone: "Asia/Tokyo",
+  });
+
+  const today = new Date(todayStr);
+  const oneWeekFromNow = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
+  const oneMonthFromNow = new Date(today.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+  const withinWeek: Task[] = [];
+  const withinMonth: Task[] = [];
+  const longTerm: Task[] = [];
+  const noDeadline: Task[] = [];
+
+  for (const { list, items } of allTasksResults) {
+    for (const task of items) {
+      if (task.due) {
+        const taskDate = new Date(task.due.slice(0, 10));
+        
+        if (taskDate > today) {
+          const taskObj = {
+            id: task.id!,
+            title: task.title ?? "(タイトルなし)",
+            due: task.due,
+            status: task.status ?? "needsAction",
+            listId: list.id!,
+            listTitle: list.title ?? "(リストなし)",
+          };
+
+          if (taskDate <= oneWeekFromNow) {
+            withinWeek.push(taskObj);
+          } else if (taskDate <= oneMonthFromNow) {
+            withinMonth.push(taskObj);
+          } else {
+            longTerm.push(taskObj);
+          }
+        }
+      } else {
+        // 期限なしのタスク
+        noDeadline.push({
+          id: task.id!,
+          title: task.title ?? "(タイトルなし)",
+          due: task.due ?? "",
+          status: task.status ?? "needsAction",
+          listId: list.id!,
+          listTitle: list.title ?? "(リストなし)",
+        });
+      }
+    }
+  }
+
+  return {
+    withinWeek: withinWeek.sort((a, b) => new Date(a.due).getTime() - new Date(b.due).getTime()),
+    withinMonth: withinMonth.sort((a, b) => new Date(a.due).getTime() - new Date(b.due).getTime()),
+    longTerm: longTerm.sort((a, b) => new Date(a.due).getTime() - new Date(b.due).getTime()),
+    noDeadline,
+  };
+}
+
 export async function fetchTodayCompletedTasks(accessToken: string): Promise<Task[]> {
   const oauth2Client = new google.auth.OAuth2();
   oauth2Client.setCredentials({ access_token: accessToken });


### PR DESCRIPTION
## 概要

Issue #47に基づき、完了リストの右隣に未来の期限に基づく4つのタスクリストを追加しました。

## 実装内容

- **一週間以内**: 明日〜１週間までの期限のタスクを表示
- **一ヶ月以内**: １週間以上〜１ヶ月以内の期限のタスクを表示
- **長期**: １ヶ月以上の期限のタスクを表示
- **期限なし**: 期限が設定されていないタスクを表示

## 変更ファイル

- `src/lib/tasks.ts`: fetchFutureTasks関数を追加
- `src/app/page.tsx`: データ取得部分を更新
- `src/app/components/TaskList.tsx`: UIコンポーネントを更新

## テスト手順

1. デスクトップで7カラム表示が正しく表示されることを確認
2. モバイルで7つのタブが正しく表示されることを確認
3. 期限変更機能が全てのリストで動作することを確認
4. タスクの完了機能が全てのリストで動作することを確認

Closes #47

🤖 Generated with [Claude Code](https://claude.ai/code)