### PR TITLE
リスト項目の幅を調整してレイアウトを改善

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -543,7 +543,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
             </div>
 
             {/* デスクトップ: 7カラム並列 */}
-            <div className="hidden lg:grid grid-cols-7 gap-4">
+            <div className="hidden lg:grid grid-cols-7 gap-4" style={{ gridTemplateColumns: "repeat(7, minmax(220px, 1fr))" }}>
               {/* 期限切れカラム */}
               <div>
                 <h2 className="text-sm font-semibold text-red-600 uppercase tracking-wide mb-3">


### PR DESCRIPTION
## 概要
リスト項目の幅が狭すぎて見づらい問題を解決しました。

## 変更内容
- 各カラムの最小幅を220pxに設定
- 横スクロールで全ての項目が見やすくなる
- 日本語テキストの表示を改善

## ファイル変更
- `src/app/components/TaskList.tsx`

## テスト手順
1. デスクトップブラウザでアクセス
2. リスト項目の幅が適切に表示されることを確認
3. 画面幅が小さい場合は横スクロールで閲覧可能なことを確認

## 関連Issue
Closes #55

🤖 Generated with [Claude Code](https://claude.ai/code)