### PR TITLE
画面幅をディスプレイサイズに合わせる対応

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -420,7 +420,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white border-b border-gray-200 px-4 py-4">
-        <div className="max-w-5xl mx-auto flex items-center justify-between">
+        <div className="w-full mx-auto flex items-center justify-between">
           <div>
             <h1 className="text-xl font-bold text-gray-800">今日のタスク</h1>
             <p className="text-sm text-gray-500">{today}</p>
@@ -476,7 +476,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 py-6 overflow-hidden">
+      <main className="w-full mx-auto px-4 py-6 overflow-hidden">
         {error && (
           <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
             {error}


### PR DESCRIPTION
## 概要

現在の画面の表示幅（横幅）はせまい為、ディスプレイに合わせる対応です。

## 変更内容

- ヘッダー部分の最大幅制限（max-w-5xl）を削除
- メインコンテンツ部分の最大幅制限（max-w-7xl）を削除
- ビューポート全体を使用するようにw-fullクラスを適用

## 効果

- ディスプレイサイズに関係なく、ブラウザの表示サイズに合わせてレイアウトが調整される
- 大画面でも小画面でも最適な表示を実現

Closes #69

🤖 Generated with [Claude Code](https://claude.ai/code)