### PR TITLE
「表示するタスクの種別」を複数設定できる機能を実装

### DIFF
--- a/src/app/components/SettingsModal.tsx
+++ b/src/app/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { getSettings, saveSettings, type AppSettings } from "@/lib/settings";
+import { getSettings, saveSettings, createTaskFilterSet, getActiveFilterSet, type AppSettings, type TaskFilterSet } from "@/lib/settings";
 import type { Task } from "@/lib/tasks";
 
 interface SettingsModalProps {
@@ -23,7 +23,11 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
       noDeadline: true,
     },
     visibleCategories: {},
+    taskFilterSets: [],
+    selectedFilterSetId: 'default',
   });
+  const [newFilterSetName, setNewFilterSetName] = useState('');
+  const [showNewFilterSetForm, setShowNewFilterSetForm] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -33,6 +37,12 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
 
   const handleSave = () => {
     saveSettings(settings);
+    onClose();
+  };
+
+  const handleCancel = () => {
+    setShowNewFilterSetForm(false);
+    setNewFilterSetName('');
     onClose();
   };
 
@@ -60,6 +70,65 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
         ...prev.visibleCategories,
         [categoryKey]: !prev.visibleCategories[categoryKey],
       },
+    }));
+  };
+
+  const handleToggleFilterSetCategory = (filterSetId: string, categoryKey: string) => {
+    setSettings(prev => ({
+      ...prev,
+      taskFilterSets: prev.taskFilterSets.map(set =>
+        set.id === filterSetId
+          ? {
+              ...set,
+              categories: {
+                ...set.categories,
+                [categoryKey]: !set.categories[categoryKey],
+              },
+            }
+          : set
+      ),
+    }));
+  };
+
+  const handleAddFilterSet = () => {
+    if (!newFilterSetName.trim()) return;
+
+    // 利用可能なカテゴリー一覧から全て有効にした状態で新しいセットを作成
+    const allCategories: Record<string, boolean> = {};
+    availableCategories.forEach(category => {
+      allCategories[category] = true;
+    });
+
+    const newFilterSet = createTaskFilterSet(newFilterSetName.trim(), allCategories);
+    setSettings(prev => ({
+      ...prev,
+      taskFilterSets: [...prev.taskFilterSets, newFilterSet],
+    }));
+    
+    setNewFilterSetName('');
+    setShowNewFilterSetForm(false);
+  };
+
+  const handleDeleteFilterSet = (filterSetId: string) => {
+    setSettings(prev => ({
+      ...prev,
+      taskFilterSets: prev.taskFilterSets.filter(set => set.id !== filterSetId),
+      selectedFilterSetId: prev.selectedFilterSetId === filterSetId 
+        ? (prev.taskFilterSets.find(set => set.isDefault)?.id || prev.taskFilterSets[0]?.id || 'default')
+        : prev.selectedFilterSetId,
+    }));
+  };
+
+  const handleUpdateFilterSetName = (filterSetId: string, newName: string) => {
+    if (!newName.trim() || newName.length > 10) return;
+    
+    setSettings(prev => ({
+      ...prev,
+      taskFilterSets: prev.taskFilterSets.map(set =>
+        set.id === filterSetId
+          ? { ...set, name: newName.trim() }
+          : set
+      ),
     }));
   };
 
@@ -133,10 +202,100 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
             </div>
           </div>
 
-          {/* タスクカテゴリー表示設定 */}
+          {/* フィルターセット管理 */}
           {availableCategories.length > 0 && (
             <div>
               <h3 className="text-sm font-medium text-gray-700 mb-3">表示するタスクの種別</h3>
+              
+              {/* 既存のフィルターセット一覧 */}
+              <div className="space-y-4">
+                {settings.taskFilterSets.map((filterSet) => (
+                  <div key={filterSet.id} className="border border-gray-200 rounded-lg p-3">
+                    <div className="flex items-center justify-between mb-2">
+                      <input
+                        type="text"
+                        value={filterSet.name}
+                        onChange={(e) => handleUpdateFilterSetName(filterSet.id, e.target.value)}
+                        maxLength={10}
+                        className="text-sm font-medium text-gray-700 border border-gray-300 rounded px-2 py-1 flex-1 mr-2"
+                        disabled={filterSet.isDefault}
+                      />
+                      {!filterSet.isDefault && (
+                        <button
+                          onClick={() => handleDeleteFilterSet(filterSet.id)}
+                          className="text-red-600 hover:text-red-800 text-xs px-2 py-1 border border-red-300 rounded hover:bg-red-50"
+                        >
+                          削除
+                        </button>
+                      )}
+                    </div>
+                    <div className="space-y-2">
+                      {availableCategories.map((category) => (
+                        <div key={category} className="flex items-center">
+                          <input
+                            type="checkbox"
+                            id={`filter-${filterSet.id}-${category}`}
+                            checked={filterSet.categories[category] !== false}
+                            onChange={() => handleToggleFilterSetCategory(filterSet.id, category)}
+                            className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                          />
+                          <label htmlFor={`filter-${filterSet.id}-${category}`} className="ml-2 text-xs text-gray-600">
+                            {category}
+                          </label>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+                
+                {/* 新しいフィルターセット追加フォーム */}
+                {showNewFilterSetForm ? (
+                  <div className="border border-gray-300 border-dashed rounded-lg p-3">
+                    <div className="flex items-center gap-2 mb-2">
+                      <input
+                        type="text"
+                        placeholder="セット名（10文字まで）"
+                        value={newFilterSetName}
+                        onChange={(e) => setNewFilterSetName(e.target.value)}
+                        maxLength={10}
+                        className="text-sm border border-gray-300 rounded px-2 py-1 flex-1"
+                        autoFocus
+                      />
+                      <button
+                        onClick={handleAddFilterSet}
+                        disabled={!newFilterSetName.trim()}
+                        className="text-xs bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        追加
+                      </button>
+                      <button
+                        onClick={() => {
+                          setShowNewFilterSetForm(false);
+                          setNewFilterSetName('');
+                        }}
+                        className="text-xs text-gray-600 hover:text-gray-800 px-2 py-1 border border-gray-300 rounded"
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                    <p className="text-xs text-gray-500">新しいセットは全てのカテゴリーがチェック済みの状態で作成されます</p>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setShowNewFilterSetForm(true)}
+                    className="w-full border border-gray-300 border-dashed rounded-lg p-3 text-sm text-gray-600 hover:text-gray-800 hover:border-gray-400"
+                  >
+                    + 新しいフィルターセットを追加
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* 旧形式のタスクカテゴリー表示設定（下位互換性のため残す） */}
+          {availableCategories.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium text-gray-700 mb-3">表示するタスクの種別（旧形式）</h3>
               <div className="space-y-3">
                 {availableCategories.map((category) => (
                   <div key={category} className="flex items-center">
@@ -159,7 +318,7 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
 
         <div className="flex justify-end gap-3 p-4 border-t border-gray-200">
           <button
-            onClick={onClose}
+            onClick={handleCancel}
             className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
           >
             キャンセル

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -4,7 +4,7 @@ import { signOut } from "next-auth/react";
 import { useState, useCallback, useEffect, useRef } from "react";
 import type { Task } from "@/lib/tasks";
 import type { User } from "next-auth";
-import { getSettings, updateCategoriesFromTasks, type AppSettings } from "@/lib/settings";
+import { getSettings, updateCategoriesFromTasks, getActiveFilterSet, saveSelectedFilterSetId, type AppSettings, type TaskFilterSet } from "@/lib/settings";
 import SettingsModal from "./SettingsModal";
 import TaskDetail from "./TaskDetail";
 
@@ -53,7 +53,10 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       noDeadline: true,
     },
     visibleCategories: {},
+    taskFilterSets: [],
+    selectedFilterSetId: 'default',
   });
+  const [selectedFilterSetId, setSelectedFilterSetId] = useState<string>('default');
   
   // スワイプ・ドラッグ関連の状態
   const [touchStart, setTouchStart] = useState<{ x: number; y: number } | null>(null);
@@ -76,7 +79,9 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
 
   // 設定の読み込み
   useEffect(() => {
-    setSettings(getSettings());
+    const loadedSettings = getSettings();
+    setSettings(loadedSettings);
+    setSelectedFilterSetId(loadedSettings.selectedFilterSetId);
   }, []);
 
   // タスクカテゴリーの設定を更新
@@ -102,13 +107,30 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   // タスクカテゴリーフィルタリング関数
   const filterTasksByCategory = (tasks: Task[]) => {
     return tasks.filter(task => {
-      // カテゴリー設定がない場合はすべて表示
+      // アクティブなフィルターセットを取得
+      const activeFilterSet = getActiveFilterSet(settings);
+      
+      // フィルターセットが存在し、かつカテゴリー設定がある場合
+      if (activeFilterSet && Object.keys(activeFilterSet.categories).length > 0) {
+        return activeFilterSet.categories[task.listTitle] !== false;
+      }
+      
+      // フォールバック：従来のvisibleCategories設定を使用
       if (Object.keys(settings.visibleCategories).length === 0) {
         return true;
       }
-      // カテゴリー設定がある場合は、明示的にfalseでない限り表示
       return settings.visibleCategories[task.listTitle] !== false;
     });
+  };
+
+  // フィルターセット切り替えハンドラー
+  const handleFilterSetChange = (filterSetId: string) => {
+    setSelectedFilterSetId(filterSetId);
+    saveSelectedFilterSetId(filterSetId);
+    
+    // 設定を再読み込み
+    const updatedSettings = getSettings();
+    setSettings(updatedSettings);
   };
 
   // フィルタリングされたタスクリスト
@@ -571,6 +593,27 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
           <div className="text-center py-16 text-gray-400">タスクを取得中...</div>
         ) : (
           <>
+            {/* フィルターセット選択タブ（複数ある場合のみ表示） */}
+            {settings.taskFilterSets.length > 1 && (
+              <div className="border-b border-gray-300 mb-4">
+                <div className="flex overflow-x-auto">
+                  {settings.taskFilterSets.map((filterSet) => (
+                    <button
+                      key={filterSet.id}
+                      onClick={() => handleFilterSetChange(filterSet.id)}
+                      className={`flex-shrink-0 px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                        selectedFilterSetId === filterSet.id
+                          ? "border-green-500 text-green-600"
+                          : "border-transparent text-gray-500 hover:text-gray-700"
+                      }`}
+                    >
+                      {filterSet.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
             {/* モバイルのみ: タブ */}
             <div className="flex lg:hidden border-b border-gray-200 mb-4 overflow-x-auto">
               {[
@@ -914,6 +957,27 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                 </div>
               )}
             </div>
+
+            {/* フィルターセット選択タブ（デスクトップ・複数ある場合のみ表示） */}
+            {settings.taskFilterSets.length > 1 && (
+              <div className="hidden lg:block border-b border-gray-300 mb-6">
+                <div className="flex overflow-x-auto">
+                  {settings.taskFilterSets.map((filterSet) => (
+                    <button
+                      key={filterSet.id}
+                      onClick={() => handleFilterSetChange(filterSet.id)}
+                      className={`flex-shrink-0 px-6 py-3 text-sm font-medium border-b-2 transition-colors ${
+                        selectedFilterSetId === filterSet.id
+                          ? "border-green-500 text-green-600"
+                          : "border-transparent text-gray-500 hover:text-gray-700"
+                      }`}
+                    >
+                      {filterSet.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
 
             {/* デスクトップ: 動的カラム数 */}
             <div 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,3 +1,10 @@
+export interface TaskFilterSet {
+  id: string;
+  name: string;
+  categories: Record<string, boolean>;
+  isDefault: boolean;
+}
+
 export interface AppSettings {
   showUserName: boolean;
   visibleLists: {
@@ -10,7 +17,16 @@ export interface AppSettings {
     noDeadline: boolean;
   };
   visibleCategories: Record<string, boolean>;
+  taskFilterSets: TaskFilterSet[];
+  selectedFilterSetId: string;
 }
+
+const DEFAULT_FILTER_SET: TaskFilterSet = {
+  id: 'default',
+  name: 'ALL',
+  categories: {},
+  isDefault: true,
+};
 
 const DEFAULT_SETTINGS: AppSettings = {
   showUserName: true,
@@ -24,9 +40,12 @@ const DEFAULT_SETTINGS: AppSettings = {
     noDeadline: true,
   },
   visibleCategories: {},
+  taskFilterSets: [DEFAULT_FILTER_SET],
+  selectedFilterSetId: 'default',
 };
 
 const SETTINGS_COOKIE_NAME = "todo-app-settings";
+const SELECTED_TAB_COOKIE_NAME = "todo-app-selected-tab";
 
 export function getSettings(): AppSettings {
   if (typeof window === "undefined") {
@@ -37,7 +56,15 @@ export function getSettings(): AppSettings {
     const stored = getCookie(SETTINGS_COOKIE_NAME);
     if (stored) {
       const parsed = JSON.parse(stored);
-      return { ...DEFAULT_SETTINGS, ...parsed };
+      const settings = { ...DEFAULT_SETTINGS, ...parsed };
+      
+      // フィルターセットが存在しない場合は初期化
+      if (!settings.taskFilterSets || settings.taskFilterSets.length === 0) {
+        settings.taskFilterSets = [DEFAULT_FILTER_SET];
+        settings.selectedFilterSetId = 'default';
+      }
+      
+      return settings;
     }
   } catch (error) {
     console.warn("設定の読み込みに失敗しました:", error);
@@ -67,12 +94,22 @@ export function updateCategoriesFromTasks(tasks: { listTitle: string }[]): void 
   const settings = getSettings();
   let needsUpdate = false;
 
-  // 新しいカテゴリーを自動的に有効化
+  // 新しいカテゴリーを自動的に有効化（既存の visibleCategories 用）
   tasks.forEach(task => {
     if (task.listTitle && !(task.listTitle in settings.visibleCategories)) {
       settings.visibleCategories[task.listTitle] = true;
       needsUpdate = true;
     }
+  });
+
+  // フィルターセットにも新しいカテゴリーを追加
+  settings.taskFilterSets.forEach(filterSet => {
+    tasks.forEach(task => {
+      if (task.listTitle && !(task.listTitle in filterSet.categories)) {
+        filterSet.categories[task.listTitle] = true;
+        needsUpdate = true;
+      }
+    });
   });
 
   if (needsUpdate) {
@@ -93,4 +130,29 @@ function setCookie(name: string, value: string, days: number): void {
   const expires = new Date();
   expires.setTime(expires.getTime() + (days * 24 * 60 * 60 * 1000));
   document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/`;
+}
+
+// フィルターセット管理のヘルパー関数
+export function getActiveFilterSet(settings: AppSettings): TaskFilterSet {
+  const activeSet = settings.taskFilterSets.find(set => set.id === settings.selectedFilterSetId);
+  return activeSet || settings.taskFilterSets[0] || DEFAULT_FILTER_SET;
+}
+
+export function createTaskFilterSet(name: string, categories: Record<string, boolean>): TaskFilterSet {
+  return {
+    id: `set_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+    name: name.slice(0, 10), // 全角10文字まで
+    categories: { ...categories },
+    isDefault: false,
+  };
+}
+
+export function saveSelectedFilterSetId(filterSetId: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const settings = getSettings();
+  settings.selectedFilterSetId = filterSetId;
+  saveSettings(settings);
 }


### PR DESCRIPTION
## 概要
「表示するタスクの種別」を複数設定できる機能を実装しました。

## 実装内容
- 複数のフィルターセットを作成・管理できる機能を追加
- 設定画面で新しいセットの追加・編集・削除が可能
- デフォルトセット「ALL」は削除不可として保護
- セット名は全角10文字まで制限
- メイン画面で複数セットがある場合のみタブ表示
- 選択されたタブは永続化され、次回表示時に復元
- 従来のvisibleCategoriesとの下位互換性を維持

## テスト手順
1. 設定画面を開き、新しいフィルターセットを追加
2. セット名の編集とカテゴリーのチェック状態変更
3. メイン画面でタブ切り替えの動作確認
4. タスク表示のフィルタリング確認
5. ページリロード後の選択タブ復元確認

Closes #73

🤖 Generated with [Claude Code](https://claude.ai/code)