### PR TITLE
fix: noDeadlineブロックの task.notes ?? undefined 漏れを修正

### DIFF
--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -166,7 +166,7 @@ export async function fetchFutureTasks(accessToken: string): Promise<{
           status: task.status ?? "needsAction",
           listId: list.id!,
           listTitle: list.title ?? "(リストなし)",
-          notes: task.notes,
+          notes: task.notes ?? undefined,
         });
       }
     }


### PR DESCRIPTION
## 関連仕様Issue
- Closes なし（ビルドエラー修正）

## 実装内容
`src/lib/tasks.ts` の `noDeadline` ブロックで `task.notes` に `?? undefined` が漏れており、TypeScript のビルドエラーが発生していた。

他の4箇所は `?? undefined` が付いていたが、169行目だけ抜けていた。

## 変更ファイル
- `src/lib/tasks.ts:169` — `notes: task.notes` → `notes: task.notes ?? undefined`

## テスト手順
- [ ] Vercel ビルドが成功することを確認
- [ ] 設定画面で「表示するタスクの種別」のフィルターセットUIが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)