### PR TITLE
fix: フィルターセットタブがデスクトップで二重表示される問題を修正

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -593,9 +593,9 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
           <div className="text-center py-16 text-gray-400">タスクを取得中...</div>
         ) : (
           <>
-            {/* フィルターセット選択タブ（複数ある場合のみ表示） */}
+            {/* フィルターセット選択タブ（モバイル・複数ある場合のみ表示） */}
             {settings.taskFilterSets.length > 1 && (
-              <div className="border-b border-gray-300 mb-4">
+              <div className="lg:hidden border-b border-gray-300 mb-4">
                 <div className="flex overflow-x-auto">
                   {settings.taskFilterSets.map((filterSet) => (
                     <button


### PR DESCRIPTION
## 関連仕様Issue
- Closes なし（バグ修正）

## 実装内容
フィルターセット選択タブがモバイル用・デスクトップ用の2箇所に実装されているが、モバイル用に `lg:hidden` が付いておらず、デスクトップでも両方表示されていた。

モバイル用タブの `<div>` に `lg:hidden` を追加して修正。

## 変更ファイル
- `src/app/components/TaskList.tsx:598` — `border-b...` → `lg:hidden border-b...`

## テスト手順
- [ ] デスクトップでタブが1行のみ表示されることを確認
- [ ] モバイルでタブが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)