### PR TITLE
fix: 設定画面の旧形式カテゴリーセクションを削除

### DIFF
--- a/src/app/components/SettingsModal.tsx
+++ b/src/app/components/SettingsModal.tsx
@@ -292,28 +292,6 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
             </div>
           )}
 
-          {/* 旧形式のタスクカテゴリー表示設定（下位互換性のため残す） */}
-          {availableCategories.length > 0 && (
-            <div>
-              <h3 className="text-sm font-medium text-gray-700 mb-3">表示するタスクの種別（旧形式）</h3>
-              <div className="space-y-3">
-                {availableCategories.map((category) => (
-                  <div key={category} className="flex items-center">
-                    <input
-                      type="checkbox"
-                      id={`category-${category}`}
-                      checked={settings.visibleCategories[category] !== false}
-                      onChange={() => handleToggleCategory(category)}
-                      className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
-                    />
-                    <label htmlFor={`category-${category}`} className="ml-2 text-sm text-gray-600">
-                      {category}
-                    </label>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
         </div>
 
         <div className="flex justify-end gap-3 p-4 border-t border-gray-200">


### PR DESCRIPTION
## 関連仕様Issue
- Closes なし（UI改善）

## 実装内容
- 「表示するタスクの種別（旧形式）」セクションを削除
- フィルターセット管理UIに完全移行
- 追加ボタンの disabled 制御（1文字以上入力時のみ有効）は既に実装済みのため変更なし

## 変更ファイル
- `src/app/components/SettingsModal.tsx` — 旧形式セクション（22行）を削除

## テスト手順
- [ ] 設定画面で「表示するタスクの種別（旧形式）」が表示されないことを確認
- [ ] フィルターセット追加フォームで名前未入力時に追加ボタンが無効化されることを確認
- [ ] セット名入力後に追加ボタンが有効化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)