### PR TITLE
fix: フィルターセット名の編集改善（空文字入力許可・保存ボタン無効化）

### DIFF
--- a/src/app/components/SettingsModal.tsx
+++ b/src/app/components/SettingsModal.tsx
@@ -36,7 +36,11 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
   }, [isOpen]);
 
   const handleSave = () => {
-    saveSettings(settings);
+    const settingsToSave = {
+      ...settings,
+      taskFilterSets: settings.taskFilterSets.map(set => ({ ...set, name: set.name.trim() })),
+    };
+    saveSettings(settingsToSave);
     onClose();
   };
 
@@ -120,13 +124,13 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
   };
 
   const handleUpdateFilterSetName = (filterSetId: string, newName: string) => {
-    if (!newName.trim() || newName.length > 10) return;
-    
+    if (newName.length > 10) return;
+
     setSettings(prev => ({
       ...prev,
       taskFilterSets: prev.taskFilterSets.map(set =>
         set.id === filterSetId
-          ? { ...set, name: newName.trim() }
+          ? { ...set, name: newName }
           : set
       ),
     }));
@@ -302,7 +306,8 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
           </button>
           <button
             onClick={handleSave}
-            className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700"
+            disabled={settings.taskFilterSets.some(s => !s.name.trim())}
+            className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             保存
           </button>


### PR DESCRIPTION
## Summary
- フィルターセット名の全文字削除を可能にし、編集中の空入力を許容
- 空名のセットが存在するとき保存ボタンを無効化
- 保存時に名前をトリムして保存

## Test plan
- [ ] セット名を全て削除したとき保存ボタンが無効化されることを確認
- [ ] 有効な名前を入力したとき保存ボタンが有効化されることを確認
- [ ] デフォルトセット（ALL）の名前を全削除→再入力して保存できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)