### PR TITLE
fix: フィルターセット名バリデーションと吹き出しトグルの改善

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -301,6 +301,12 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
     // モバイルでは長押しで詳細表示するため、通常クリックでは何もしない
     if (isMobile() || !task.notes) return;
 
+    // 同じタスクをクリックした場合は吹き出しを閉じる
+    if (selectedTask?.id === task.id) {
+      handleCloseDetail();
+      return;
+    }
+
     // デスクトップでタスクにnotesがある場合は詳細を表示
     const rect = event.currentTarget.getBoundingClientRect();
     setDetailPosition({


### PR DESCRIPTION
## Summary
- フィルターセット名の空文字入力を許可し、保存時にトリムして保存ボタンを無効化
- デフォルトフィルターセットの名前を編集可能に変更
- 同じタスクを再クリック/タップで吹き出しを閉じる（デスクトップ）

## Test plan
- [ ] フィルターセット名を空にした状態で保存ボタンが無効になることを確認
- [ ] デフォルトフィルターセット（ALL）の名前が編集できることを確認
- [ ] notesありのタスクをクリックして吹き出しが表示され、再クリックで閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)