### PR TITLE
feat: プライバシーポリシー・利用規約ページを追加

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,103 @@
+export const metadata = {
+  title: "プライバシーポリシー | 今日のタスク",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-12 text-gray-800">
+      <h1 className="text-2xl font-bold mb-8">プライバシーポリシー</h1>
+
+      <p className="mb-6 text-sm text-gray-500">最終更新日：2026年3月27日</p>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">1. はじめに</h2>
+        <p>
+          本アプリ「今日のタスク」（以下「本サービス」）は、Google Tasks
+          と連携してタスク管理を行うウェブアプリケーションです。
+          本ポリシーでは、本サービスが取得・利用する情報について説明します。
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">2. 取得する情報</h2>
+        <p className="mb-3">
+          本サービスは、Googleアカウントによるログイン時に以下の情報を取得します。
+        </p>
+        <ul className="list-disc pl-6 space-y-1">
+          <li>メールアドレス</li>
+          <li>氏名（Googleプロフィール名）</li>
+          <li>プロフィール画像URL</li>
+          <li>Google Tasks のタスクリストおよびタスク内容</li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">3. 情報の利用目的</h2>
+        <p>取得した情報は、以下の目的にのみ使用します。</p>
+        <ul className="list-disc pl-6 space-y-1 mt-3">
+          <li>ユーザー認証およびセッション管理</li>
+          <li>Google Tasks からのタスク表示・更新機能の提供</li>
+          <li>画面上のユーザー名・アイコンの表示</li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">4. データの保存について</h2>
+        <p className="mb-3">
+          本サービスは、ユーザーのタスクデータや個人情報を独自のサーバーやデータベースに保存しません。
+          タスクデータはリクエストのたびにGoogle Tasks
+          APIから直接取得し、表示します。
+        </p>
+        <p>
+          ただし、以下のデータはお使いのブラウザに保存されます。
+        </p>
+        <ul className="list-disc pl-6 space-y-1 mt-3">
+          <li>
+            <strong>認証セッション（Cookie）</strong>：ログイン状態の維持に使用。ブラウザを閉じるか、ログアウト時に削除されます。
+          </li>
+          <li>
+            <strong>アプリ設定（Cookie）</strong>：表示設定（タスクリストの表示/非表示など）。有効期限は365日です。
+          </li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">5. 第三者への提供</h2>
+        <p>
+          取得した情報を第三者に販売・提供・開示することはありません。
+          ただし、本サービスはGoogle LLC のAPIを利用しており、Googleのプライバシーポリシーが適用されます。
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">6. データの削除・連携解除</h2>
+        <p className="mb-3">
+          本サービスへのアクセス許可を取り消すには、以下の手順でGoogleアカウントのアプリ連携を解除してください。
+        </p>
+        <ol className="list-decimal pl-6 space-y-1">
+          <li>
+            Googleアカウントの「セキュリティ」設定を開く
+          </li>
+          <li>「サードパーティへのアクセス」から本アプリを選択</li>
+          <li>「アクセス権を削除」をクリック</li>
+        </ol>
+        <p className="mt-3">
+          連携解除後、本サービスはお客様のGoogleアカウント情報およびタスクデータにアクセスできなくなります。
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">7. お問い合わせ</h2>
+        <p>
+          本ポリシーに関するご質問は、GitHubリポジトリのIssueからお問い合わせください。
+        </p>
+      </section>
+
+      <div className="mt-12 pt-6 border-t border-gray-200">
+        <a href="/" className="text-sm text-blue-600 hover:underline">
+          ← トップページに戻る
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,74 @@
+export const metadata = {
+  title: "利用規約 | 今日のタスク",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-12 text-gray-800">
+      <h1 className="text-2xl font-bold mb-8">利用規約</h1>
+
+      <p className="mb-6 text-sm text-gray-500">最終更新日：2026年3月27日</p>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">1. サービスの概要</h2>
+        <p>
+          「今日のタスク」（以下「本サービス」）は、Google Tasks
+          と連携し、本日期限のタスクや期限切れタスクを管理するためのウェブアプリケーションです。
+          本規約は、本サービスを利用するすべてのユーザーに適用されます。
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">2. 利用条件</h2>
+        <p>本サービスを利用するには、以下の条件を満たす必要があります。</p>
+        <ul className="list-disc pl-6 space-y-1 mt-3">
+          <li>有効なGoogleアカウントを保有していること</li>
+          <li>本規約およびプライバシーポリシーに同意していること</li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">3. 禁止事項</h2>
+        <p>ユーザーは、以下の行為を行ってはなりません。</p>
+        <ul className="list-disc pl-6 space-y-1 mt-3">
+          <li>本サービスへの不正アクセスや、過度な負荷をかける行為</li>
+          <li>本サービスを利用した違法行為</li>
+          <li>その他、本サービスの運営を妨げる行為</li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">4. 免責事項</h2>
+        <p className="mb-3">
+          本サービスは現状有姿で提供されます。以下について、運営者は一切の責任を負いません。
+        </p>
+        <ul className="list-disc pl-6 space-y-1">
+          <li>本サービスの中断・停止・変更・廃止によって生じた損害</li>
+          <li>Google Tasks API の仕様変更や障害によって生じた損害</li>
+          <li>ユーザーのタスクデータの消失または誤操作によって生じた損害</li>
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">5. サービスの変更・終了</h2>
+        <p>
+          運営者は、事前の通知なく本サービスの内容を変更し、または提供を終了することがあります。
+          予めご了承ください。
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-3">6. 規約の変更</h2>
+        <p>
+          本規約は、必要に応じて変更される場合があります。変更後の規約は本ページに掲載した時点で効力を生じます。
+        </p>
+      </section>
+
+      <div className="mt-12 pt-6 border-t border-gray-200">
+        <a href="/" className="text-sm text-blue-600 hover:underline">
+          ← トップページに戻る
+        </a>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `/privacy` にプライバシーポリシーページを追加
- `/terms` に利用規約ページを追加
- Google OAuth 同意画面への URL 登録が目的

## Test plan
- [ ] `/privacy` にアクセスしてページが表示されることを確認
- [ ] `/terms` にアクセスしてページが表示されることを確認
- [ ] 「← トップページに戻る」リンクが機能することを確認
- [ ] デプロイ後、Google Cloud Console > OAuth 同意画面に URL を登録

🤖 Generated with [Claude Code](https://claude.com/claude-code)