### PR TITLE
fix: プライバシー・利用規約ページのダークモード対応

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -4,6 +4,7 @@ export const metadata = {
 
 export default function PrivacyPage() {
   return (
+    <div className="min-h-screen bg-white">
     <div className="max-w-2xl mx-auto px-6 py-12 text-gray-800">
       <h1 className="text-2xl font-bold mb-8">プライバシーポリシー</h1>
 
@@ -98,6 +99,7 @@ export default function PrivacyPage() {
           ← トップページに戻る
         </a>
       </div>
+    </div>
     </div>
   );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -4,6 +4,7 @@ export const metadata = {
 
 export default function TermsPage() {
   return (
+    <div className="min-h-screen bg-white">
     <div className="max-w-2xl mx-auto px-6 py-12 text-gray-800">
       <h1 className="text-2xl font-bold mb-8">利用規約</h1>
 
@@ -69,6 +70,7 @@ export default function TermsPage() {
           ← トップページに戻る
         </a>
       </div>
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- globals.css のダークモード設定（body背景が #0a0a0a）の影響で /privacy・/terms ページが暗くなる問題を修正
- 両ページの外側に `min-h-screen bg-white` を追加し、OSカラーモードに関わらず白背景で表示

## Test plan
- [ ] OSをダークモードに設定した状態で /privacy にアクセスし、白背景・黒文字で表示されることを確認
- [ ] 同様に /terms を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)