### PR TITLE
feat: プライバシーポリシー・利用規約への導線を追加

### DIFF
--- a/src/app/components/LoginButton.tsx
+++ b/src/app/components/LoginButton.tsx
@@ -35,6 +35,14 @@ export default function LoginButton() {
         </svg>
         Google でログイン
       </button>
+      <div className="flex gap-4 text-xs text-gray-400">
+        <a href="/privacy" className="hover:text-gray-600 hover:underline">
+          プライバシーポリシー
+        </a>
+        <a href="/terms" className="hover:text-gray-600 hover:underline">
+          利用規約
+        </a>
+      </div>
     </div>
   );
 }

--- a/src/app/components/SettingsModal.tsx
+++ b/src/app/components/SettingsModal.tsx
@@ -295,6 +295,29 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
             </div>
           )}
 
+          {/* このアプリについて */}
+          <div>
+            <h3 className="text-sm font-medium text-gray-700 mb-3">このアプリについて</h3>
+            <div className="space-y-2">
+              <a
+                href="/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block text-sm text-blue-600 hover:text-blue-800 hover:underline"
+              >
+                プライバシーポリシー
+              </a>
+              <a
+                href="/terms"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block text-sm text-blue-600 hover:text-blue-800 hover:underline"
+              >
+                利用規約
+              </a>
+            </div>
+          </div>
+
         </div>
 
         <div className="flex justify-end gap-3 p-4 border-t border-gray-200">


### PR DESCRIPTION
## Summary
- ログイン画面のボタン下部にプライバシーポリシー・利用規約へのリンクを追加
- 設定画面の最下部に「このアプリについて」セクションを追加し、両ページへのリンクを設置

## Test plan
- [ ] ログイン画面（未認証状態）でプライバシーポリシー・利用規約リンクが表示される
- [ ] 設定画面の最下部に「このアプリについて」セクションが表示される
- [ ] 各リンクをクリックして正しいページに遷移できる（設定画面は別タブで開く）

🤖 Generated with [Claude Code](https://claude.com/claude-code)