### PR TITLE
fix: タスク追加・編集・削除後に全タブを再取得する

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "auth";
 import { google } from "googleapis";
-import { fetchTodayTasks, fetchExpiredTasks } from "@/lib/tasks";
+import { fetchTodayTasks, fetchExpiredTasks, fetchTodayCompletedTasks, fetchFutureTasks } from "@/lib/tasks";
 
 export async function GET() {
   const session = await auth();
@@ -11,11 +11,13 @@ export async function GET() {
   }
 
   try {
-    const [todayTasks, expiredTasks] = await Promise.all([
+    const [todayTasks, expiredTasks, completedTasks, futureTasks] = await Promise.all([
       fetchTodayTasks(session.accessToken as string),
       fetchExpiredTasks(session.accessToken as string),
+      fetchTodayCompletedTasks(session.accessToken as string),
+      fetchFutureTasks(session.accessToken as string),
     ]);
-    return NextResponse.json({ todayTasks, expiredTasks });
+    return NextResponse.json({ todayTasks, expiredTasks, completedTasks, futureTasks });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("Google Tasks API error:", message);

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -166,6 +166,10 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       const data = await res.json();
       setIncompleteTasks(data.todayTasks ?? []);
       setExpiredTasks(data.expiredTasks ?? []);
+      setCompletedTasks(data.completedTasks ?? []);
+      if (data.futureTasks) {
+        setFutureTasks(data.futureTasks);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "エラーが発生しました");
     } finally {


### PR DESCRIPTION
## Summary
- `GET /api/tasks` に `completedTasks` と `futureTasks` を追加
- `fetchTasks` クライアント側で完了タスク・未来タスクのステートも更新するよう修正
- これにより追加・編集・削除後に全タブの表示が正しく反映される

## Test plan
- [ ] タスク追加後、該当タブ（本日/未来）に新しいタスクが表示される
- [ ] タスク編集後、変更内容が全タブに反映される
- [ ] タスク削除後、該当タスクが全タブから消える
- [ ] 「更新」ボタンで全タブが最新状態に更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)