### PR TITLE
fix: タスク追加・編集モーダルの入力テキスト色を修正

### DIFF
--- a/src/app/components/TaskAddModal.tsx
+++ b/src/app/components/TaskAddModal.tsx
@@ -102,7 +102,7 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Prop
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
               placeholder="タスク内容を入力"
             />
           </div>
@@ -117,7 +117,7 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Prop
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none text-gray-900"
               placeholder="詳細を入力（任意）"
             />
           </div>

--- a/src/app/components/TaskEditModal.tsx
+++ b/src/app/components/TaskEditModal.tsx
@@ -83,7 +83,7 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
               placeholder="タスク内容を入力"
             />
           </div>
@@ -98,7 +98,7 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none text-gray-900"
               placeholder="詳細を入力（任意）"
             />
           </div>


### PR DESCRIPTION
## 関連仕様Issue
- なし（バグ修正）

## 実装内容
タスク追加・編集モーダルで、入力済みテキストがプレースホルダーと同じ薄い色で表示されて読みにくい問題を修正。

## 変更ファイル
- `src/app/components/TaskAddModal.tsx` — タスク内容・詳細フィールドに `text-gray-900` を追加
- `src/app/components/TaskEditModal.tsx` — タスク内容・詳細フィールドに `text-gray-900` を追加

## テスト手順
- [ ] タスク追加モーダルを開き、タスク内容・詳細に文字を入力して黒く読みやすく表示されることを確認
- [ ] タスク編集モーダルを開き、既存の値・入力テキストが黒く読みやすく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)