### PR TITLE
fix: モーダルのselect・datetime-localのテキスト色を修正

### DIFF
--- a/src/app/components/TaskAddModal.tsx
+++ b/src/app/components/TaskAddModal.tsx
@@ -82,7 +82,7 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Prop
               id="task-list"
               value={listId}
               onChange={(e) => setListId(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
             >
               {taskLists.map((list) => (
                 <option key={list.id} value={list.id}>
@@ -132,7 +132,7 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Prop
               type="datetime-local"
               value={due}
               onChange={(e) => setDue(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
             />
             <div className="text-xs text-gray-500 mt-1">
               未入力の場合は今日の期限として設定されます

--- a/src/app/components/TaskEditModal.tsx
+++ b/src/app/components/TaskEditModal.tsx
@@ -113,7 +113,7 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
               type="datetime-local"
               value={due}
               onChange={(e) => setDue(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
             />
           </div>
         </div>


### PR DESCRIPTION
## 関連仕様Issue
- なし（バグ修正）

## 実装内容
タスク追加・編集モーダルで、タスク種別（select）と期限（datetime-local）の選択値・入力値が薄い色で表示されて読みにくい問題を修正。

## 変更ファイル
- `src/app/components/TaskAddModal.tsx` — select・datetime-local に `text-gray-900` を追加
- `src/app/components/TaskEditModal.tsx` — datetime-local に `text-gray-900` を追加

## テスト手順
- [ ] タスク追加モーダルで「タスク種別」を選択し、選択値が黒く読みやすく表示されることを確認
- [ ] タスク追加モーダルで「期限」を入力し、値が黒く読みやすく表示されることを確認
- [ ] タスク編集モーダルで「期限」の値が黒く読みやすく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)