### PR TITLE
fix: タスクメニューの編集・期限変更が反応しないバグを修正

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -595,9 +595,9 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       }
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('click', handleClickOutside);
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
     };
   }, [showTaskMenu]);
 


### PR DESCRIPTION
## Summary
- タスクメニュー（⋮）の「編集」「期限変更」をクリックしても何も表示されないバグを修正
- `handleClickOutside` のイベントを `mousedown` から `click` に変更
- `mousedown` で先にメニューがDOMから消えていたため、ボタンの `onClick` が発火しなかった

## Test plan
- [ ] タスクの「⋮」→「編集」をクリックして編集モーダルが開くことを確認
- [ ] タスクの「⋮」→「期限変更」をクリックして日付入力が表示されることを確認
- [ ] メニュー外をクリックしてメニューが閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)