### PR TITLE
fix: モーダルオーバーレイをすりガラス（frosted glass）エフェクトに変更

### DIFF
--- a/src/app/components/SettingsModal.tsx
+++ b/src/app/components/SettingsModal.tsx
@@ -144,7 +144,7 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg max-w-md w-full max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between p-4 border-b border-gray-200">
           <h2 className="text-lg font-semibold text-gray-800">設定</h2>

--- a/src/app/components/TaskAddModal.tsx
+++ b/src/app/components/TaskAddModal.tsx
@@ -57,7 +57,7 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Prop
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg max-w-md w-full p-6">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-semibold text-gray-800">新規タスク追加</h2>

--- a/src/app/components/TaskDetail.tsx
+++ b/src/app/components/TaskDetail.tsx
@@ -98,7 +98,7 @@ export default function TaskDetail({ task, isVisible, position, onClose, isMobil
   if (isMobile) {
     // モバイル版：ダイアログ表示
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-sm p-4">
         <div
           ref={detailRef}
           className="bg-white rounded-lg shadow-xl max-w-sm w-full max-h-96 overflow-hidden"

--- a/src/app/components/TaskEditModal.tsx
+++ b/src/app/components/TaskEditModal.tsx
@@ -47,7 +47,7 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg max-w-md w-full p-6">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-semibold text-gray-800">タスク編集</h2>

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -2015,7 +2015,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       />
 
       {showLogoutConfirm && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg max-w-xs w-full p-6">
             <p className="text-gray-800 text-sm mb-6">ログアウトしますか？</p>
             <div className="flex justify-end gap-3">


### PR DESCRIPTION
## Summary
- 全モーダルの背景を `bg-black bg-opacity-50`（黒50%）から `bg-black/20 backdrop-blur-sm`（黒20% + ぼかし）に変更
- 対象: TaskAddModal, TaskEditModal, SettingsModal, TaskDetail（モバイル）, ログアウト確認ダイアログ

## Test plan
- [ ] タスク追加・編集モーダルを開き、背景がぼけて表示されることを確認（PC・モバイル）
- [ ] 設定モーダル、ログアウト確認ダイアログも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)