### PR TITLE
fix: 一週間以内タスクをチェックしても消えないバグを修正

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -195,6 +195,12 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       });
       setIncompleteTasks((prev) => prev.filter((t) => t.id !== task.id));
       setExpiredTasks((prev) => prev.filter((t) => t.id !== task.id));
+      setFutureTasks((prev) => ({
+        withinWeek: prev.withinWeek.filter((t) => t.id !== task.id),
+        withinMonth: prev.withinMonth.filter((t) => t.id !== task.id),
+        longTerm: prev.longTerm.filter((t) => t.id !== task.id),
+        noDeadline: prev.noDeadline.filter((t) => t.id !== task.id),
+      }));
       setCompletedTasks((prev) => [task, ...prev]);
       setNewlyCompleted((prev) => new Set(prev).add(task.id));
 
@@ -216,6 +222,9 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         const data = await syncRes.json();
         setIncompleteTasks(data.todayTasks);
         setExpiredTasks(data.expiredTasks);
+        if (data.futureTasks) {
+          setFutureTasks(data.futureTasks);
+        }
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "エラーが発生しました");


### PR DESCRIPTION
## Summary
- `completeTask` の楽観的更新で `futureTasks` が除外されていなかった問題を修正
- API同期後に `futureTasks` が再設定されていなかった問題を修正

## Test plan
- [ ] 一週間以内タブのタスクをチェックして即座にリストから消えることを確認
- [ ] 一ヶ月以内・長期・期限なしタブでも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)