### PR TITLE
feat: フィルタ済みタスク種別のみを新規タスク追加時の選択肢として表示

### DIFF
--- a/src/app/components/TaskAddModal.tsx
+++ b/src/app/components/TaskAddModal.tsx
@@ -7,9 +7,10 @@ type Props = {
   onClose: () => void;
   onAdd: (listId: string, title: string, notes: string, due: string) => Promise<void>;
   taskLists: { id: string; title: string }[];
+  filteredTaskLists?: { id: string; title: string }[];
 };
 
-export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Props) {
+export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists, filteredTaskLists }: Props) {
   const [listId, setListId] = useState("");
   const [title, setTitle] = useState("");
   const [notes, setNotes] = useState("");
@@ -19,13 +20,14 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Prop
   // モーダルが開かれた時にリセット
   useEffect(() => {
     if (isOpen) {
-      setListId(taskLists.length > 0 ? taskLists[0].id : "");
+      const availableLists = filteredTaskLists || taskLists;
+      setListId(availableLists.length > 0 ? availableLists[0].id : "");
       setTitle("");
       setNotes("");
       setDue("");
       setAdding(false);
     }
-  }, [isOpen, taskLists]);
+  }, [isOpen, taskLists, filteredTaskLists]);
 
   if (!isOpen) return null;
 
@@ -84,7 +86,7 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Prop
               onChange={(e) => setListId(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
             >
-              {taskLists.map((list) => (
+              {(filteredTaskLists || taskLists).map((list) => (
                 <option key={list.id} value={list.id}>
                   {list.title}
                 </option>

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -155,6 +155,45 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
     noDeadline: filterTasksByCategory(futureTasks.noDeadline),
   };
 
+  // 現在のタブに基づいてフィルタリングされたタスクリストを取得
+  const getFilteredTaskListsForCurrentTab = () => {
+    let currentTabTasks: Task[] = [];
+    
+    switch (activeTab) {
+      case "expired":
+        currentTabTasks = filteredExpiredTasks;
+        break;
+      case "today":
+        currentTabTasks = filteredIncompleteTasks;
+        break;
+      case "completed":
+        currentTabTasks = filteredCompletedTasks;
+        break;
+      case "withinWeek":
+        currentTabTasks = filteredFutureTasks.withinWeek;
+        break;
+      case "withinMonth":
+        currentTabTasks = filteredFutureTasks.withinMonth;
+        break;
+      case "longTerm":
+        currentTabTasks = filteredFutureTasks.longTerm;
+        break;
+      case "noDeadline":
+        currentTabTasks = filteredFutureTasks.noDeadline;
+        break;
+      default:
+        currentTabTasks = filteredIncompleteTasks;
+    }
+
+    // 現在のタブのタスクから固有のタスクリスト種別を抽出
+    const uniqueListTitles = new Set(currentTabTasks.map(task => task.listTitle));
+    
+    // taskListsからマッチするものだけをフィルタリング
+    return taskLists.filter(list => uniqueListTitles.has(list.title));
+  };
+
+  const filteredTaskListsForCurrentTab = getFilteredTaskListsForCurrentTab();
+
   const fetchTasks = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -2012,6 +2051,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         onClose={() => setShowAddTaskModal(false)}
         onAdd={addTask}
         taskLists={taskLists}
+        filteredTaskLists={filteredTaskListsForCurrentTab}
       />
 
       {showLogoutConfirm && (


### PR DESCRIPTION
## 概要
タスク追加時のタスク種別の選択肢を、現在選択されているタブに表示されているタスク種別のみにフィルタリングします。

## 実装内容
- タスク追加モーダルにfilteredTaskListsプロパティを追加
- 現在のアクティブなタブに表示されているタスクの種別のみを抽出する機能を実装

## テスト手順
1. アプリケーションを起動
2. 異なるタブ（本日、期限切れ、完了等）を選択
3. タスク追加ボタンを押下
4. タスク種別の選択肢が現在のタブに表示されているタスクの種別のみになっていることを確認

Closes #103

🤖 Generated with [Claude Code](https://claude.ai/code)