### PR TITLE
fix: 期限なしでタスク追加すると期限なしリストに入らないバグを修正

### DIFF
--- a/src/app/components/TaskAddModal.tsx
+++ b/src/app/components/TaskAddModal.tsx
@@ -42,11 +42,9 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Prop
 
     setAdding(true);
     try {
-      // 日付形式をISO形式に変換（未入力の場合は今日の日付を設定）
-      const isoDate = due 
-        ? new Date(due).toISOString()
-        : new Date().toISOString().slice(0, 10) + "T00:00:00.000Z";
-      
+      // 日付形式をISO形式に変換（未入力の場合は空文字のまま渡す）
+      const isoDate = due ? `${due}:00.000Z` : "";
+
       await onAdd(listId, title.trim(), notes.trim(), isoDate);
       onClose();
     } catch (e) {
@@ -135,7 +133,7 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists }: Prop
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
             />
             <div className="text-xs text-gray-500 mt-1">
-              未入力の場合は今日の期限として設定されます
+              未入力の場合は期限なしとして設定されます
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 関連仕様Issue
- Closes #

## 実装内容
期限未入力時に今日の日付をデフォルト設定していたため、全タスクに期限が付与され期限なしリストに追加されなかった問題を修正。

## 変更ファイル
- `src/app/components/TaskAddModal.tsx` — 期限未入力時に空文字を渡すよう変更、ヘルプテキスト修正

## テスト手順
- [ ] 期限を設定せずにタスクを追加し、期限なしリストに表示されることを確認
- [ ] 期限を設定してタスクを追加し、対応するリスト（今週・今月等）に表示されることを確認

## スクリーンショット
<!-- UI変更がある場合は画像を添付してください -->

## 備考
- 日付変換も `new Date().toISOString()` から `` `${due}:00.000Z` `` に変更し、タイムゾーンずれを防止

🤖 Generated with [Claude Code](https://claude.com/claude-code)