### PR TITLE
fix: タスク完了後のサーバー同期で完了タスクがリストに再表示されるバグを修正

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -220,10 +220,15 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       const syncRes = await fetch("/api/tasks");
       if (syncRes.ok) {
         const data = await syncRes.json();
-        setIncompleteTasks(data.todayTasks);
-        setExpiredTasks(data.expiredTasks);
+        setIncompleteTasks((data.todayTasks ?? []).filter((t: Task) => t.id !== task.id));
+        setExpiredTasks((data.expiredTasks ?? []).filter((t: Task) => t.id !== task.id));
         if (data.futureTasks) {
-          setFutureTasks(data.futureTasks);
+          setFutureTasks({
+            withinWeek: data.futureTasks.withinWeek.filter((t: Task) => t.id !== task.id),
+            withinMonth: data.futureTasks.withinMonth.filter((t: Task) => t.id !== task.id),
+            longTerm: data.futureTasks.longTerm.filter((t: Task) => t.id !== task.id),
+            noDeadline: data.futureTasks.noDeadline.filter((t: Task) => t.id !== task.id),
+          });
         }
       }
     } catch (e) {


### PR DESCRIPTION
## 関連仕様Issue
- Closes #

## 実装内容
タスク完了後に `/api/tasks` を再取得した際、Google Tasks API の反映遅延により完了タスクが各リストに再追加されていた問題を修正。

`completeTask` のサーバー同期処理で、完了タスクのIDを `todayTasks` / `expiredTasks` / `futureTasks`（withinWeek / withinMonth / longTerm / noDeadline）すべてから除外するよう変更。

## 変更ファイル
- `src/app/components/TaskList.tsx` — サーバー同期時に完了タスクIDを全リストからフィルタ除外

## テスト手順
- [ ] 期限なしタスクを完了にし、期限なしリストに再表示されないことを確認
- [ ] 期限ありタスクを完了にし、対応するリスト（今日・今週等）に再表示されないことを確認

## スクリーンショット
<!-- UI変更がある場合は画像を添付してください -->

## 備考
楽観的更新でUIから除去した後、`setFutureTasks(data.futureTasks)` で上書きされるのが根本原因。Google Tasks API はPATCH直後のGETで変更を反映していない場合があるため、クライアント側でも完了タスクを除外する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)