### PR TITLE
fix: タスク完了時に status: "completed" が送信されていなかったバグを修正

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -184,7 +184,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
     const patchPromise = fetch("/api/tasks", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ taskId: task.id, listId: task.listId }),
+      body: JSON.stringify({ taskId: task.id, listId: task.listId, status: "completed" }),
     });
 
     setTimeout(() => {


### PR DESCRIPTION
## 関連仕様Issue
- Closes #

## 実装内容
`completeTask` のPATCHリクエストに `status` フィールドが欠落していたため、Google Tasks上でタスクが実際には完了状態にならず、ページリフレッシュ後に期限なしリストに再表示されていた問題を修正。

## 変更ファイル
- `src/app/components/TaskList.tsx` — PATCHリクエストに `status: "completed"` を追加

## テスト手順
- [ ] 期限なしタスクを完了にしてページをリフレッシュし、期限なしリストに再表示されないことを確認
- [ ] 完了済みタスクが完了リストに正しく表示されることを確認

## 備考
楽観的更新でUI上は完了に見えていたため発見が遅れた。実際には Google Tasks 上でステータスが変更されておらず、リフレッシュで真の状態（`needsAction`）が反映されていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)