### PR TITLE
fix: トークンリフレッシュエラーログをJSON.stringifyで文字列化

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -55,7 +55,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           expiresAt: Math.floor(Date.now() / 1000) + refreshed.expires_in,
         };
       } catch (err) {
-        console.error("[auth] Token refresh failed:", err);
+        const errMsg = err instanceof Error ? err.message : JSON.stringify(err);
+        console.error("[auth] Token refresh failed:", errMsg);
         return { ...token, error: "RefreshTokenError" };
       }
     },


### PR DESCRIPTION
## 関連仕様Issue
なし（軽微なログ改善）

## 実装内容
トークンリフレッシュ失敗時の `console.error` に渡すエラーオブジェクトを文字列化するよう修正。`Error` インスタンスなら `.message`、それ以外は `JSON.stringify` を使用。

## 変更ファイル
- `auth.ts`: エラーログの文字列化

## テスト手順
- [ ] トークンリフレッシュが失敗するケースでログが文字列で出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)