### PR TITLE
fix: タスク追加モーダルのリスト選択肢をフィルターセット設定に基づいて表示

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -176,39 +176,15 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
 
   // 現在のタブに基づいてフィルタリングされたタスクリストを取得
   const getFilteredTaskListsForCurrentTab = () => {
-    let currentTabTasks: Task[] = [];
-    
-    switch (activeTab) {
-      case "expired":
-        currentTabTasks = filteredExpiredTasks;
-        break;
-      case "today":
-        currentTabTasks = filteredIncompleteTasks;
-        break;
-      case "completed":
-        currentTabTasks = filteredCompletedTasks;
-        break;
-      case "withinWeek":
-        currentTabTasks = filteredFutureTasks.withinWeek;
-        break;
-      case "withinMonth":
-        currentTabTasks = filteredFutureTasks.withinMonth;
-        break;
-      case "longTerm":
-        currentTabTasks = filteredFutureTasks.longTerm;
-        break;
-      case "noDeadline":
-        currentTabTasks = filteredFutureTasks.noDeadline;
-        break;
-      default:
-        currentTabTasks = filteredIncompleteTasks;
+    const activeFilterSet = getActiveFilterSet(settings);
+
+    // ALLタブ（デフォルト）またはカテゴリー設定がない場合はすべてのタスクリストを返す
+    if (activeFilterSet.isDefault || Object.keys(activeFilterSet.categories).length === 0) {
+      return taskLists;
     }
 
-    // 現在のタブのタスクから固有のタスクリスト種別を抽出
-    const uniqueListTitles = new Set(currentTabTasks.map(task => task.listTitle));
-    
-    // taskListsからマッチするものだけをフィルタリング
-    return taskLists.filter(list => uniqueListTitles.has(list.title));
+    // 現在のフィルターセットでチェックONのカテゴリーのみをフィルタリング
+    return taskLists.filter(list => activeFilterSet.categories[list.title] !== false);
   };
 
   const filteredTaskListsForCurrentTab = getFilteredTaskListsForCurrentTab();


### PR DESCRIPTION
## Summary
- ALLタブ選択時にタスク追加モーダルで全タスク種別が選択肢に表示されない不具合を修正
- タスク選択肢の絞り込みを「タブ内の既存タスクから逆引き」→「フィルターセットのcategories設定を直接参照」に変更
- 個別フィルターセット選択時はチェックONのカテゴリーのみ、ALLタブは全タスク種別を返すよう整理

## Test plan
- [ ] ALLタブでタスク追加モーダルを開き、全タスク種別（リスト）が選択肢に表示されること
- [ ] 個別フィルターセット（タスク種別チェックON/OFF設定済み）でタスク追加モーダルを開き、ONのものだけが選択肢に表示されること
- [ ] タスク追加後、選択したリストにタスクが追加されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)