### PR TITLE
fix: 操作履歴をCookieからlocalStorageに変更し記録漏れを修正

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -257,6 +257,15 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       const res = await patchPromise;
       if (!res.ok) throw new Error("更新に失敗しました");
 
+      // タスク完了の履歴を記録（PATCH成功直後、sync前に記録）
+      addTaskHistoryItem(
+        "complete",
+        task.id,
+        task.title,
+        { ...task, status: "needsAction" },
+        { ...task, status: "completed" }
+      );
+
       const syncRes = await fetch("/api/tasks");
       if (syncRes.ok) {
         const data = await syncRes.json();
@@ -276,15 +285,6 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
           return [task, ...prev];
         });
       }
-      
-      // タスク完了の履歴を記録
-      addTaskHistoryItem(
-        "complete",
-        task.id,
-        task.title,
-        { ...task, status: "needsAction" },
-        { ...task, status: "completed" }
-      );
     } catch (e) {
       setError(e instanceof Error ? e.message : "エラーが発生しました");
       setCompletedTasks((prev) => prev.filter((t) => t.id !== task.id));
@@ -355,6 +355,15 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       const res = await patchPromise;
       if (!res.ok) throw new Error("更新に失敗しました");
 
+      // タスク未完了の履歴を記録（PATCH成功直後、sync前に記録）
+      addTaskHistoryItem(
+        "uncomplete",
+        task.id,
+        task.title,
+        { ...task, status: "completed" },
+        { ...task, status: "needsAction" }
+      );
+
       const syncRes = await fetch("/api/tasks");
       if (syncRes.ok) {
         const data = await syncRes.json();
@@ -406,15 +415,6 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
           }
         }
       }
-      
-      // タスク未完了の履歴を記録
-      addTaskHistoryItem(
-        "uncomplete",
-        task.id,
-        task.title,
-        { ...task, status: "completed" },
-        { ...task, status: "needsAction" }
-      );
     } catch (e) {
       setError(e instanceof Error ? e.message : "エラーが発生しました");
       // On error, restore task to completed list and remove from where it was added

--- a/src/lib/taskHistory.ts
+++ b/src/lib/taskHistory.ts
@@ -20,50 +20,38 @@ export interface TaskHistoryItem {
   currentState?: Partial<Task>;  // 操作後のタスクの状態
 }
 
-// Cookie関連の定数
-const HISTORY_COOKIE_KEY = "task_history";
+// localStorage関連の定数
+const HISTORY_STORAGE_KEY = "task_history";
 const MAX_HISTORY_ITEMS = 20;
 
-// Cookieからタスク操作履歴を取得
+// localStorageからタスク操作履歴を取得
 export function getTaskHistory(): TaskHistoryItem[] {
   if (typeof window === "undefined") return [];
-  
+
   try {
-    const cookieValue = document.cookie
-      .split("; ")
-      .find(row => row.startsWith(`${HISTORY_COOKIE_KEY}=`))
-      ?.split("=")[1];
-    
-    if (!cookieValue) return [];
-    
-    const decodedValue = decodeURIComponent(cookieValue);
-    const history = JSON.parse(decodedValue) as TaskHistoryItem[];
-    
+    const value = localStorage.getItem(HISTORY_STORAGE_KEY);
+    if (!value) return [];
+
+    const history = JSON.parse(value) as TaskHistoryItem[];
+
     // 新しい順にソート
     return history.sort((a, b) => b.timestamp - a.timestamp);
   } catch (error) {
-    console.error("Failed to parse task history from cookie:", error);
+    console.error("Failed to parse task history from localStorage:", error);
     return [];
   }
 }
 
-// タスク操作履歴をCookieに保存
+// タスク操作履歴をlocalStorageに保存
 export function saveTaskHistory(history: TaskHistoryItem[]): void {
   if (typeof window === "undefined") return;
-  
+
   try {
     // 最新の20件のみ保持
     const limitedHistory = history.slice(0, MAX_HISTORY_ITEMS);
-    const jsonValue = JSON.stringify(limitedHistory);
-    const encodedValue = encodeURIComponent(jsonValue);
-    
-    // Cookieの有効期限を30日に設定
-    const expirationDate = new Date();
-    expirationDate.setDate(expirationDate.getDate() + 30);
-    
-    document.cookie = `${HISTORY_COOKIE_KEY}=${encodedValue}; expires=${expirationDate.toUTCString()}; path=/; SameSite=Lax`;
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(limitedHistory));
   } catch (error) {
-    console.error("Failed to save task history to cookie:", error);
+    console.error("Failed to save task history to localStorage:", error);
   }
 }
 


### PR DESCRIPTION
## Summary
- 操作履歴の保存先をCookie（4KB上限）からlocalStorage（5〜10MB）に変更し、日本語テキストを含むタスクでサイレントに失敗していた問題を修正
- `completeTask` / `uncompleteTask` で `addTaskHistoryItem` の呼び出しを同期GET前に移動し、sync失敗時に履歴が記録されないバグを修正

## Test plan
- [ ] タスクを完了 → 操作履歴モーダルを開き「タスク完了」が表示される
- [ ] 複数回タスクを完了・未完了を繰り返し、20件超えても履歴が正常に更新される
- [ ] Undo ボタンで完了取消が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)