### PR TITLE
fix: Google Tasks API スコープ不足時に自動で再認証にリダイレクト

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,13 +17,23 @@ export default async function Home() {
     redirect("/api/auth/signin?provider=google");
   }
 
-  const [tasks, expiredTasks, completedTasks, futureTasks, tomorrowTasks] = await Promise.all([
-    fetchTodayTasks(session.accessToken as string),
-    fetchExpiredTasks(session.accessToken as string),
-    fetchTodayCompletedTasks(session.accessToken as string),
-    fetchFutureTasks(session.accessToken as string),
-    fetchTomorrowTasks(session.accessToken as string),
-  ]);
+  let tasks, expiredTasks, completedTasks, futureTasks, tomorrowTasks;
+  try {
+    [tasks, expiredTasks, completedTasks, futureTasks, tomorrowTasks] = await Promise.all([
+      fetchTodayTasks(session.accessToken as string),
+      fetchExpiredTasks(session.accessToken as string),
+      fetchTodayCompletedTasks(session.accessToken as string),
+      fetchFutureTasks(session.accessToken as string),
+      fetchTomorrowTasks(session.accessToken as string),
+    ]);
+  } catch (err: unknown) {
+    const status = (err as { status?: number; code?: number })?.status ?? (err as { status?: number; code?: number })?.code;
+    if (status === 403) {
+      // スコープ不足 → 再認証（consent画面を強制表示）
+      redirect("/api/auth/signin?provider=google");
+    }
+    throw err;
+  }
 
   return <TaskList initialTasks={tasks} initialExpiredTasks={expiredTasks} initialCompletedTasks={completedTasks} initialFutureTasks={futureTasks} initialTomorrowTasks={tomorrowTasks} user={session.user} />;
 }


### PR DESCRIPTION
## Summary
- `page.tsx` の Tasks API 呼び出しで 403 エラー（スコープ不足）が発生した場合、`/api/auth/signin` へリダイレクトして再認証を強制するように修正
- 既存の `RefreshTokenError` ハンドリングと同様のフォールバック動作を追加

## Test plan
- [ ] ログアウト → ログインで正常にタスクが表示されることを確認
- [ ] スコープ不足のセッションでアクセスした際、ログイン画面にリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)