### PR TITLE
feat: 新規タスク作成時に日付と時刻を分離

### DIFF
--- a/src/app/components/TaskAddModal.tsx
+++ b/src/app/components/TaskAddModal.tsx
@@ -14,7 +14,8 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists, filter
   const [listId, setListId] = useState("");
   const [title, setTitle] = useState("");
   const [notes, setNotes] = useState("");
-  const [due, setDue] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [dueTime, setDueTime] = useState("");
   const [adding, setAdding] = useState(false);
 
   // モーダルが開かれた時にリセット
@@ -24,7 +25,8 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists, filter
       setListId(availableLists.length > 0 ? availableLists[0].id : "");
       setTitle("");
       setNotes("");
-      setDue("");
+      setDueDate("");
+      setDueTime("");
       setAdding(false);
     }
   }, [isOpen, taskLists, filteredTaskLists]);
@@ -44,8 +46,16 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists, filter
 
     setAdding(true);
     try {
-      // 日付形式をISO形式に変換（未入力の場合は空文字のまま渡す）
-      const isoDate = due ? `${due}:00.000Z` : "";
+      // 日付と時刻を組み合わせてISO形式に変換
+      let isoDate = "";
+      if (dueDate) {
+        if (dueTime) {
+          isoDate = `${dueDate}T${dueTime}:00.000Z`;
+        } else {
+          // 時刻が未設定の場合は23:59に設定
+          isoDate = `${dueDate}T23:59:00.000Z`;
+        }
+      }
 
       await onAdd(listId, title.trim(), notes.trim(), isoDate);
       onClose();
@@ -122,22 +132,41 @@ export default function TaskAddModal({ isOpen, onClose, onAdd, taskLists, filter
             />
           </div>
 
-          {/* 期限 */}
+          {/* 期限日 */}
           <div>
-            <label htmlFor="add-task-due" className="block text-sm font-medium text-gray-700 mb-1">
-              期限
+            <label htmlFor="add-task-due-date" className="block text-sm font-medium text-gray-700 mb-1">
+              期限日
             </label>
             <input
-              id="add-task-due"
-              type="datetime-local"
-              value={due}
-              onChange={(e) => setDue(e.target.value)}
+              id="add-task-due-date"
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
             />
             <div className="text-xs text-gray-500 mt-1">
               未入力の場合は期限なしとして設定されます
             </div>
           </div>
+
+          {/* 期限時刻 */}
+          {dueDate && (
+            <div>
+              <label htmlFor="add-task-due-time" className="block text-sm font-medium text-gray-700 mb-1">
+                期限時刻
+              </label>
+              <input
+                id="add-task-due-time"
+                type="time"
+                value={dueTime}
+                onChange={(e) => setDueTime(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
+              />
+              <div className="text-xs text-gray-500 mt-1">
+                未入力の場合は23:59に設定されます
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="flex justify-end gap-3 mt-6">

--- a/src/app/components/TaskEditModal.tsx
+++ b/src/app/components/TaskEditModal.tsx
@@ -18,7 +18,8 @@ type Props = {
 export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) {
   const [title, setTitle] = useState("");
   const [notes, setNotes] = useState("");
-  const [due, setDue] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [dueTime, setDueTime] = useState("");
   const [selectedListId, setSelectedListId] = useState("");
   const [taskLists, setTaskLists] = useState<TaskList[]>([]);
   const [saving, setSaving] = useState(false);
@@ -45,7 +46,20 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
     if (task) {
       setTitle(task.title);
       setNotes(task.notes || "");
-      setDue(task.due ? task.due.slice(0, 16) : ""); // YYYY-MM-DDTHH:MM形式
+      // 既存の期限を日付と時刻に分割
+      if (task.due) {
+        const dueDateTime = new Date(task.due);
+        const year = dueDateTime.getFullYear();
+        const month = String(dueDateTime.getMonth() + 1).padStart(2, '0');
+        const day = String(dueDateTime.getDate()).padStart(2, '0');
+        const hours = String(dueDateTime.getHours()).padStart(2, '0');
+        const minutes = String(dueDateTime.getMinutes()).padStart(2, '0');
+        setDueDate(`${year}-${month}-${day}`);
+        setDueTime(`${hours}:${minutes}`);
+      } else {
+        setDueDate("");
+        setDueTime("");
+      }
       setSelectedListId(task.listId);
     }
   }, [task]);
@@ -67,8 +81,19 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
 
     setSaving(true);
     try {
-      // 日付形式をISO形式に変換
-      const isoDate = due ? `${due}:00.000Z` : task.due;
+      // 日付と時刻を組み合わせてISO形式に変換
+      let isoDate = task.due; // デフォルトは既存の値
+      if (dueDate) {
+        if (dueTime) {
+          isoDate = `${dueDate}T${dueTime}:00.000Z`;
+        } else {
+          // 時刻が未設定の場合は23:59に設定
+          isoDate = `${dueDate}T23:59:00.000Z`;
+        }
+      } else if (dueDate === "") {
+        // 日付が空の場合は期限をクリア
+        isoDate = "";
+      }
       // リストが変更された場合は新しいリストIDを渡す
       const newListId = selectedListId !== task.listId ? selectedListId : undefined;
       await onSave(task, title.trim(), notes.trim(), isoDate, newListId);
@@ -152,19 +177,41 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
             />
           </div>
 
-          {/* 期限 */}
+          {/* 期限日 */}
           <div>
-            <label htmlFor="task-due" className="block text-sm font-medium text-gray-700 mb-1">
-              期限
+            <label htmlFor="task-due-date" className="block text-sm font-medium text-gray-700 mb-1">
+              期限日
             </label>
             <input
-              id="task-due"
-              type="datetime-local"
-              value={due}
-              onChange={(e) => setDue(e.target.value)}
+              id="task-due-date"
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
             />
+            <div className="text-xs text-gray-500 mt-1">
+              空にすると期限なしになります
+            </div>
           </div>
+
+          {/* 期限時刻 */}
+          {dueDate && (
+            <div>
+              <label htmlFor="task-due-time" className="block text-sm font-medium text-gray-700 mb-1">
+                期限時刻
+              </label>
+              <input
+                id="task-due-time"
+                type="time"
+                value={dueTime}
+                onChange={(e) => setDueTime(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
+              />
+              <div className="text-xs text-gray-500 mt-1">
+                未入力の場合は23:59に設定されます
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="flex justify-end gap-3 mt-6">


### PR DESCRIPTION
## 概要

新規タスク作成時に日付と時刻の設定を分離しました。

## 変更内容

- `datetime-local`から`date` + `time`の分離されたUIに変更
- 日付が設定された場合のみ時刻入力フィールドを表示
- 時刻が未設定の場合、自動で23:59に設定
- TaskAddModalとTaskEditModalの両方を更新

Closes #127

🤖 Generated with [Claude Code](https://claude.ai/code)