### PR TITLE
feat: ブラウジング中の日付変更検出とポップアップ機能

### DIFF
--- a/src/app/components/DateChangeDetector.tsx
+++ b/src/app/components/DateChangeDetector.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface DateChangeDetectorProps {
+  onDateChange: () => void;
+  isEnabled: boolean;
+}
+
+export default function DateChangeDetector({ onDateChange, isEnabled }: DateChangeDetectorProps) {
+  const lastKnownDate = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isEnabled) return;
+
+    // 現在の日付を取得（日本時間）
+    const getCurrentDate = () => {
+      return new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+    };
+
+    // 初期値設定
+    lastKnownDate.current = getCurrentDate();
+
+    const checkDateChange = () => {
+      const currentDate = getCurrentDate();
+      
+      if (lastKnownDate.current && lastKnownDate.current !== currentDate) {
+        lastKnownDate.current = currentDate;
+        onDateChange();
+      } else if (!lastKnownDate.current) {
+        lastKnownDate.current = currentDate;
+      }
+    };
+
+    // 1分間隔でチェック
+    const interval = setInterval(checkDateChange, 60000);
+
+    // Page Visibility APIでタブがアクティブになった際にもチェック
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        checkDateChange();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [onDateChange, isEnabled]);
+
+  // このコンポーネントは何もレンダリングしない
+  return null;
+}

--- a/src/app/components/DateChangePopup.tsx
+++ b/src/app/components/DateChangePopup.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface DateChangePopupProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  isUpdating?: boolean;
+}
+
+export default function DateChangePopup({ isOpen, onConfirm, isUpdating = false }: DateChangePopupProps) {
+  // ESCキーでの閉じるを無効化
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div 
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[9999]"
+      onClick={(e) => e.stopPropagation()} // クリックイベントの伝播を防ぐ
+    >
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+        <div className="text-center">
+          {/* アイコン */}
+          <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 mb-4">
+            <svg 
+              className="h-6 w-6 text-blue-600" 
+              fill="none" 
+              viewBox="0 0 24 24" 
+              stroke="currentColor"
+            >
+              <path 
+                strokeLinecap="round" 
+                strokeLinejoin="round" 
+                strokeWidth={2} 
+                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" 
+              />
+            </svg>
+          </div>
+
+          {/* タイトルとメッセージ */}
+          <h3 className="text-lg font-medium text-gray-900 mb-2">
+            日付が変更されました
+          </h3>
+          
+          {isUpdating ? (
+            <div className="text-sm text-gray-600 mb-6">
+              <div className="flex items-center justify-center gap-2">
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
+                <span>更新中...</span>
+              </div>
+              <p className="mt-2">しばらくお待ちください</p>
+            </div>
+          ) : (
+            <div className="text-sm text-gray-600 mb-6">
+              <p>タスクリストを最新の状態に更新します。</p>
+              <p className="mt-2 text-orange-600">
+                ※ 編集中の操作はキャンセルされます
+              </p>
+            </div>
+          )}
+
+          {/* ボタン */}
+          {!isUpdating && (
+            <div className="flex justify-center">
+              <button
+                onClick={onConfirm}
+                className="inline-flex justify-center px-6 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+              >
+                OK
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -12,6 +12,8 @@ import TaskDetail from "./TaskDetail";
 import TaskEditModal from "./TaskEditModal";
 import TaskAddModal from "./TaskAddModal";
 import TaskHistoryModal from "./TaskHistoryModal";
+import DateChangeDetector from "./DateChangeDetector";
+import DateChangePopup from "./DateChangePopup";
 
 type Props = {
   initialTasks: Task[];
@@ -75,6 +77,10 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
     selectedFilterSetId: 'default',
   });
   const [selectedFilterSetId, setSelectedFilterSetId] = useState<string>('default');
+  
+  // 日付変更検出関連の状態
+  const [showDateChangePopup, setShowDateChangePopup] = useState(false);
+  const [isDateChangeUpdating, setIsDateChangeUpdating] = useState(false);
   
   // スワイプ・ドラッグ関連の状態
   const [touchStart, setTouchStart] = useState<{ x: number; y: number } | null>(null);
@@ -730,6 +736,53 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   useEffect(() => {
     fetchTaskLists();
   }, [fetchTaskLists]);
+
+  // 編集中の全状態をクリアする関数
+  const clearAllEditingStates = useCallback(() => {
+    setEditingTask(null);
+    setShowAddTaskModal(false);
+    setShowSettings(false);
+    setShowHistoryModal(false);
+    setShowTaskMenu(null);
+    setDatePickerTask(null);
+    setShowLogoutConfirm(false);
+    setSelectedTask(null);
+    setDetailPosition(null);
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      setLongPressTimer(null);
+    }
+    setIsSwiping(false);
+    setIsDragging(false);
+    setTouchStart(null);
+    setTouchEnd(null);
+    setDragStart(null);
+    setDraggedTask(null);
+    setDraggedFrom(null);
+  }, [longPressTimer]);
+
+  // 日付変更検出時の処理
+  const handleDateChange = useCallback(() => {
+    // まず編集状態をクリア
+    clearAllEditingStates();
+    // ポップアップ表示
+    setShowDateChangePopup(true);
+  }, [clearAllEditingStates]);
+
+  // 日付変更ポップアップのOK処理
+  const handleDateChangeConfirm = useCallback(async () => {
+    setIsDateChangeUpdating(true);
+    try {
+      // タスクリストとタスクリスト一覧を更新
+      await Promise.all([fetchTasks(), fetchTaskLists()]);
+    } catch (error) {
+      console.error("日付変更時の更新エラー:", error);
+      setError("更新中にエラーが発生しました");
+    } finally {
+      setIsDateChangeUpdating(false);
+      setShowDateChangePopup(false);
+    }
+  }, [fetchTasks, fetchTaskLists]);
 
   // ドラッグ&ドロップ関数
   const handleDragStart = (e: React.DragEvent, task: Task) => {
@@ -2541,6 +2594,19 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
           </div>
         </div>
       )}
+
+      {/* 日付変更検出 */}
+      <DateChangeDetector 
+        onDateChange={handleDateChange}
+        isEnabled={!showDateChangePopup && !isDateChangeUpdating}
+      />
+
+      {/* 日付変更ポップアップ */}
+      <DateChangePopup 
+        isOpen={showDateChangePopup}
+        onConfirm={handleDateChangeConfirm}
+        isUpdating={isDateChangeUpdating}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
ブラウジング中の日付変更検出とポップアップによるリスト更新機能を実装しました。

## 実装内容
- 1分間隔 + Page Visibility APIによる日付変更検出
- 編集中操作の自動キャンセル（15の状態変数をクリア）
- 強制モーダルポップアップ（ESCキー無効、最高z-index）
- タスクリスト・タスクリスト一覧の自動更新
- 更新中の全操作無効化（ローディング表示）

## 変更ファイル
- DateChangeDetector.tsx – 日付変更検出コンポーネント
- DateChangePopup.tsx – ポップアップモーダルコンポーネント
- TaskList.tsx – メインコンポーネントへの統合

## テスト手順
1. アプリケーションを開く
2. タスク編集モーダルや設定画面を開く
3. システム時間を00:00を跨ぐ（または検証用に1分間隔を短くする）
4. 日付変更ポップアップが表示されるOKを押す
5. 編集中の操作がキャンセルされ、タスクリストが最新に更新されることを確認

Closes #129

🤖 Generated with [Claude Code](https://claude.ai/code)