### PR TITLE
fix: D&Dを妨げていた親コンテナの preventDefault を回避

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -946,18 +946,24 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   // デスクトップでのマウスドラッグスクロール
   const handleMouseDown = (e: React.MouseEvent) => {
     if (isMobile()) return;
-    
+
+    // draggable なカード（またはその子要素）上で押下した場合は、
+    // ネイティブ HTML5 ドラッグを優先するためスクロールドラッグを開始しない。
+    // preventDefault() を呼ぶと dragstart が発火しなくなるため、ここで抜ける。
+    const target = e.target as HTMLElement | null;
+    if (target?.closest('[draggable="true"]')) return;
+
     const container = containerRef.current;
     if (!container) return;
-    
+
     setIsDragging(true);
     setDragStart({ x: e.clientX, y: e.clientY });
     setScrollStart({ left: container.scrollLeft, top: container.scrollTop });
-    
+
     // カーソルを掴み状態に変更
     document.body.style.cursor = 'grabbing';
     document.body.style.userSelect = 'none';
-    
+
     e.preventDefault();
   };
 


### PR DESCRIPTION
## Summary
- デスクトップの横スクロール用 `handleMouseDown` が無条件で `e.preventDefault()` を呼んでおり、子の TaskCard 上で `dragstart` が発火せず D&D が動作しない問題を修正
- `draggable="true"` 要素内で押下された場合はスクロールドラッグを初期化せず、ネイティブ HTML5 ドラッグに任せる

## Test plan
- [ ] デスクトップでタスクカードをドラッグして別カテゴリのカラムにドロップできる（today → tomorrow, withinWeek → completed 等）
- [ ] カラム間の余白領域をマウスドラッグすると従来通り横スクロールする
- [ ] カード上のボタン（完了・メニュー）クリックが従来通り動作する
- [ ] モバイル（タッチ）では D&D が発動しない（既存挙動維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)