### PR TITLE
fix: 編集保存と削除のUI反映を即時化

### DIFF
--- a/src/app/components/TaskEditModal.tsx
+++ b/src/app/components/TaskEditModal.tsx
@@ -22,7 +22,6 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
   const [dueTime, setDueTime] = useState("");
   const [selectedListId, setSelectedListId] = useState("");
   const [taskLists, setTaskLists] = useState<TaskList[]>([]);
-  const [saving, setSaving] = useState(false);
   const [loadingLists, setLoadingLists] = useState(false);
 
   // タスクリストを取得
@@ -73,36 +72,32 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
 
   if (!isOpen || !task) return null;
 
-  const handleSave = async () => {
+  const handleSave = () => {
     if (!title.trim()) {
       alert("タスク名を入力してください");
       return;
     }
 
-    setSaving(true);
-    try {
-      // 日付と時刻を組み合わせてISO形式に変換
-      let isoDate = task.due; // デフォルトは既存の値
-      if (dueDate) {
-        if (dueTime) {
-          isoDate = `${dueDate}T${dueTime}:00.000Z`;
-        } else {
-          // 時刻が未設定の場合は23:59に設定
-          isoDate = `${dueDate}T23:59:00.000Z`;
-        }
-      } else if (dueDate === "") {
-        // 日付が空の場合は期限をクリア
-        isoDate = "";
+    // 日付と時刻を組み合わせてISO形式に変換
+    let isoDate = task.due; // デフォルトは既存の値
+    if (dueDate) {
+      if (dueTime) {
+        isoDate = `${dueDate}T${dueTime}:00.000Z`;
+      } else {
+        // 時刻が未設定の場合は23:59に設定
+        isoDate = `${dueDate}T23:59:00.000Z`;
       }
-      // リストが変更された場合は新しいリストIDを渡す
-      const newListId = selectedListId !== task.listId ? selectedListId : undefined;
-      await onSave(task, title.trim(), notes.trim(), isoDate, newListId);
-      onClose();
-    } catch (e) {
-      // エラーハンドリングは親コンポーネントで行う
-    } finally {
-      setSaving(false);
+    } else if (dueDate === "") {
+      // 日付が空の場合は期限をクリア
+      isoDate = "";
     }
+    // リストが変更された場合は新しいリストIDを渡す
+    const newListId = selectedListId !== task.listId ? selectedListId : undefined;
+
+    // モーダルを即座に閉じ、保存処理はバックグラウンドで継続
+    // （エラーは親コンポーネントの setError で処理される）
+    onClose();
+    void onSave(task, title.trim(), notes.trim(), isoDate, newListId).catch(() => {});
   };
 
   return (
@@ -217,17 +212,16 @@ export default function TaskEditModal({ task, isOpen, onClose, onSave }: Props) 
         <div className="flex justify-end gap-3 mt-6">
           <button
             onClick={onClose}
-            disabled={saving}
-            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 disabled:opacity-50"
+            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
           >
             キャンセル
           </button>
           <button
             onClick={handleSave}
-            disabled={saving || !title.trim()}
+            disabled={!title.trim()}
             className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {saving ? "保存中..." : "保存"}
+            保存
           </button>
         </div>
       </div>

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -61,7 +61,6 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
     setShowTaskMenu((cur) => (cur === k ? null : k));
   };
   const [editingTask, setEditingTask] = useState<Task | null>(null);
-  const [deletingTask, setDeletingTask] = useState<string | null>(null);
   const [showAddTaskModal, setShowAddTaskModal] = useState(false);
   const [showHistoryModal, setShowHistoryModal] = useState(false);
   const [taskLists, setTaskLists] = useState<{ id: string; title: string }[]>([]);
@@ -611,8 +610,18 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   };
 
   const deleteTask = async (task: Task) => {
-    setDeletingTask(task.id);
     setShowTaskMenu(null);
+
+    // 楽観的削除: 全カラムから即座に除去
+    setIncompleteTasks((prev) => prev.filter((t) => t.id !== task.id));
+    setExpiredTasks((prev) => prev.filter((t) => t.id !== task.id));
+    setCompletedTasks((prev) => prev.filter((t) => t.id !== task.id));
+    setTomorrowTasks((prev) => prev.filter((t) => t.id !== task.id));
+    setFutureTasks((prev) => ({
+      withinWeek: prev.withinWeek.filter((t) => t.id !== task.id),
+      withinMonth: prev.withinMonth.filter((t) => t.id !== task.id),
+      noDeadline: prev.noDeadline.filter((t) => t.id !== task.id),
+    }));
 
     try {
       const res = await fetch("/api/tasks", {
@@ -623,7 +632,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
 
       if (!res.ok) throw new Error("タスクの削除に失敗しました");
 
-      // 削除の履歴を記録（削除前に記録）
+      // 削除の履歴を記録（PATCH成功直後、sync前に記録）
       addTaskHistoryItem(
         "delete",
         task.id,
@@ -632,12 +641,12 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         undefined
       );
 
-      // タスクリストを再取得
+      // バックグラウンドでサーバー同期（モーダルは既に閉じている）
       await fetchTasks();
     } catch (e) {
       setError(e instanceof Error ? e.message : "エラーが発生しました");
-    } finally {
-      setDeletingTask(null);
+      // 失敗時は再取得して正しい状態に戻す
+      fetchTasks();
     }
   };
 
@@ -1320,7 +1329,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                     <div className="space-y-2">
                       {filteredExpiredTasks.map((task) => (
                         <TaskCard key={task.id} task={task} variant="expired"
-                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "expired")}
+                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "expired")}
                           onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                           onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
                           onMenuToggle={() => toggleTaskMenu(task.id, "expired")}
@@ -1343,7 +1352,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                     <div className="space-y-2">
                       {filteredIncompleteTasks.map((task) => (
                         <TaskCard key={task.id} task={task} variant="today"
-                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "today")}
+                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "today")}
                           onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                           onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
                           onMenuToggle={() => toggleTaskMenu(task.id, "today")}
@@ -1383,7 +1392,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                     <div className="space-y-2">
                       {filteredTomorrowTasks.map((task) => (
                         <TaskCard key={task.id} task={task} variant="tomorrow"
-                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "tomorrow")}
+                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "tomorrow")}
                           onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                           onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
                           onMenuToggle={() => toggleTaskMenu(task.id, "tomorrow")}
@@ -1404,7 +1413,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                     <div className="space-y-2">
                       {filteredFutureTasks.withinWeek.map((task) => (
                         <TaskCard key={task.id} task={task} variant="withinWeek"
-                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "withinWeek")}
+                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "withinWeek")}
                           onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                           onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
                           onMenuToggle={() => toggleTaskMenu(task.id, "withinWeek")}
@@ -1425,7 +1434,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                     <div className="space-y-2">
                       {filteredFutureTasks.withinMonth.map((task) => (
                         <TaskCard key={task.id} task={task} variant="withinMonth"
-                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "withinMonth")}
+                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "withinMonth")}
                           onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                           onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
                           onMenuToggle={() => toggleTaskMenu(task.id, "withinMonth")}
@@ -1446,7 +1455,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                     <div className="space-y-2">
                       {filteredFutureTasks.noDeadline.map((task) => (
                         <TaskCard key={task.id} task={task} variant="noDeadline"
-                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "noDeadline")}
+                          isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "noDeadline")}
                           onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                           onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
                           onMenuToggle={() => toggleTaskMenu(task.id, "noDeadline")}
@@ -1508,7 +1517,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                   <div className="space-y-2">
                     {filteredExpiredTasks.map((task) => (
                       <TaskCard key={task.id} task={task} variant="expired"
-                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "expired")}
+                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "expired")}
                         draggable={!isMobile()} onDragStart={(e) => handleDragStart(e, task, "expired")} onDragEnd={handleDragEnd}
                         onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                         onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
@@ -1547,7 +1556,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                   <div className="space-y-2">
                     {filteredIncompleteTasks.map((task) => (
                       <TaskCard key={task.id} task={task} variant="today"
-                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "today")}
+                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "today")}
                         draggable={!isMobile()} onDragStart={(e) => handleDragStart(e, task, "today")} onDragEnd={handleDragEnd}
                         onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                         onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
@@ -1581,7 +1590,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                   <div className="space-y-2">
                     {filteredTomorrowTasks.map((task) => (
                       <TaskCard key={task.id} task={task} variant="tomorrow"
-                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "tomorrow")}
+                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "tomorrow")}
                         draggable={!isMobile()} onDragStart={(e) => handleDragStart(e, task, "tomorrow")} onDragEnd={handleDragEnd}
                         onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                         onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
@@ -1647,7 +1656,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                   <div className="space-y-2">
                     {filteredFutureTasks.withinWeek.map((task) => (
                       <TaskCard key={task.id} task={task} variant="withinWeek"
-                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "withinWeek")}
+                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "withinWeek")}
                         draggable={!isMobile()} onDragStart={(e) => handleDragStart(e, task, "withinWeek")} onDragEnd={handleDragEnd}
                         onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                         onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
@@ -1681,7 +1690,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                   <div className="space-y-2">
                     {filteredFutureTasks.withinMonth.map((task) => (
                       <TaskCard key={task.id} task={task} variant="withinMonth"
-                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "withinMonth")}
+                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "withinMonth")}
                         draggable={!isMobile()} onDragStart={(e) => handleDragStart(e, task, "withinMonth")} onDragEnd={handleDragEnd}
                         onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                         onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}
@@ -1715,7 +1724,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
                   <div className="space-y-2">
                     {filteredFutureTasks.noDeadline.map((task) => (
                       <TaskCard key={task.id} task={task} variant="noDeadline"
-                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isDeleting={deletingTask === task.id} isMenuOpen={isTaskMenuOpen(task.id, "noDeadline")}
+                        isCompleting={completing.has(task.id)} isChangingDue={changingDue.has(task.id)} isMenuOpen={isTaskMenuOpen(task.id, "noDeadline")}
                         draggable={!isMobile()} onDragStart={(e) => handleDragStart(e, task, "noDeadline")} onDragEnd={handleDragEnd}
                         onComplete={() => completeTask(task)} onEdit={() => { setEditingTask(task); setShowTaskMenu(null); }} onDelete={() => deleteTask(task)} onDatePickerOpen={(e) => openDatePicker(task, e)}
                         onClick={(e) => handleTaskClick(task, e)} onTouchStart={(e) => handleTaskTouchStart(task, e)} onTouchEnd={handleTaskTouchEnd} onTouchMove={handleTaskTouchMove}


### PR DESCRIPTION
## Summary
- 編集モーダルの保存ボタン押下で `onSave` を待たずに即時クローズ
- 削除操作を楽観的更新に変更し、DELETE API を待たずにカードを即時除去（失敗時は fetchTasks で復元）
- 不要になった saving / deletingTask 関連のstateとローディング表示を削除

## Test plan
- [ ] タスク編集モーダルで保存ボタン押下後、モーダルが即座に閉じることを確認
- [ ] 編集後、カードが更新された内容で表示されることを確認
- [ ] タスク削除ボタン押下後、カードが即座に消えることを確認
- [ ] バリデーション（編集タイトル未入力）が従来どおり alert で警告されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)