### PR TITLE
fix: 連続ドロップ時のフリッカと読み取りエラーを修正

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -69,6 +69,13 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   const draggedTaskRef = useRef<Task | null>(null);
   const draggedFromRef = useRef<TabKey | null>(null);
   const [dragOverTarget, setDragOverTarget] = useState<TabKey | null>(null);
+  // 連続ドロップ時のレース防止:
+  //   - taskOpGenerationRef: fetchTasks の世代番号。新しい操作（特に新たなドロップ）が
+  //     入った時点で in-flight の GET レスポンスを無効化する
+  //   - dragInFlightRef: 進行中のドロップ PATCH 数。バースト中は最後の1回だけ
+  //     fetchTasks を撃つようコアレスする
+  const taskOpGenerationRef = useRef(0);
+  const dragInFlightRef = useRef(0);
   const [showSettings, setShowSettings] = useState(false);
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
   const [settings, setSettings] = useState<AppSettings>({
@@ -211,15 +218,21 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   const filteredTaskListsForCurrentTab = getFilteredTaskListsForCurrentTab();
 
   const fetchTasks = useCallback(async () => {
+    // 世代番号: 同時に複数の fetchTasks が in-flight になった場合、
+    // または fetchTasks 中に新たなドロップ等が入った場合、
+    // 古いレスポンスでローカル状態を上書きしないようガードする
+    const gen = ++taskOpGenerationRef.current;
     setLoading(true);
     setError(null);
     try {
       const res = await fetch("/api/tasks");
+      if (gen !== taskOpGenerationRef.current) return; // 古い世代 → 破棄
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(body.detail ?? "タスクの取得に失敗しました");
       }
       const data = await res.json();
+      if (gen !== taskOpGenerationRef.current) return; // 古い世代 → 破棄
       setIncompleteTasks(data.todayTasks ?? []);
       setExpiredTasks(data.expiredTasks ?? []);
       setCompletedTasks(data.completedTasks ?? []);
@@ -228,9 +241,10 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         setFutureTasks(data.futureTasks);
       }
     } catch (e) {
+      if (gen !== taskOpGenerationRef.current) return; // 古い世代のエラーは握り潰す
       setError(e instanceof Error ? e.message : "エラーが発生しました");
     } finally {
-      setLoading(false);
+      if (gen === taskOpGenerationRef.current) setLoading(false);
     }
   }, []);
 
@@ -880,6 +894,20 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
     setDraggedTask(null);
     setDraggedFrom(null);
 
+    // 進行中の fetchTasks があれば、その応答が後で楽観的更新を上書きするのを防ぐため
+    // 世代番号をインクリメントして無効化する
+    taskOpGenerationRef.current++;
+    dragInFlightRef.current += 1;
+
+    const finalizeDragSync = () => {
+      dragInFlightRef.current -= 1;
+      // 連続ドロップを 1 回の fetchTasks にコアレスする (Google Tasks API 負荷軽減 +
+      // PATCH_A 完了後 PATCH_B 完了前に GET が走って B が一瞬戻る現象を防止)
+      if (dragInFlightRef.current === 0) {
+        fetchTasks();
+      }
+    };
+
     // 楽観的更新: 元バケットから即時除去し、移動先バケットに即時追加
     const removeFromBucket = (tab: TabKey) => {
       switch (tab) {
@@ -914,10 +942,10 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
           { ...task, status: "needsAction" },
           updatedTask
         );
-        fetchTasks();
       } catch (err) {
         setError(err instanceof Error ? err.message : "エラーが発生しました");
-        fetchTasks();
+      } finally {
+        finalizeDragSync();
       }
     } else {
       const newDue = getDueDateForCategory(dropTarget) ?? "";
@@ -944,10 +972,10 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         if (!res.ok) throw new Error("期限の変更に失敗しました");
 
         addTaskHistoryItem("changeDue", task.id, task.title, { ...task }, updatedTask);
-        fetchTasks();
       } catch (err) {
         setError(err instanceof Error ? err.message : "エラーが発生しました");
-        fetchTasks();
+      } finally {
+        finalizeDragSync();
       }
     }
   };


### PR DESCRIPTION
## Summary
- 連続して 2 タスクを別タブへドラッグ&ドロップすると 2 つ目のタスクが一瞬元のタブに表示される問題を修正
- 同条件で「タスクの取得に失敗しました」エラーが出るケースも併せて解消
- `fetchTasks` に世代番号、`handleDrop` に in-flight カウンタを導入

## 原因
`handleDrop` が PATCH 完了直後に独立して `fetchTasks` を撃つため、PATCH_A 完了 → GET_A が PATCH_B 完了前にサーバー到達 → Google Tasks API が B 未反映のスナップショットを返し、`setIncompleteTasks` 等で B の楽観的更新を上書きしていた。さらに `/api/tasks` GET は内部で 5 本の Google API 並列呼び出しを行うため、2 つの GET + 2 つの PATCH 同時実行で同時呼び出し数が瞬間的に 12〜14 本となり、レート制限/500 で `fetchTasks` 自体が失敗していた。

## 修正
- `fetchTasks` に世代番号 (`taskOpGenerationRef`) を導入。レスポンス到着時に世代が変わっていれば結果を破棄
- `handleDrop` 開始時に世代番号をインクリメントし、in-flight の古い `fetchTasks` を無効化
- `dragInFlightRef` で進行中ドロップ数をカウントし、バーストの最後の 1 回だけ `fetchTasks` を呼ぶようコアレス

## Test plan
- [ ] 2 つのタスクを連続で別タブへドラッグ → どちらも目的のタブに留まり、元のタブへ戻る瞬間がない
- [ ] 高頻度に複数タスクを移動しても「タスクの取得に失敗しました」エラーが出ない
- [ ] 単一タスクのドラッグ&ドロップが従来通り動作する
- [ ] 通信失敗時、最後の 1 回の `fetchTasks` で正しい状態に復元される

🤖 Generated with [Claude Code](https://claude.com/claude-code)