### PR TITLE
fix: ドラッグ大量操作時のOAuthロック・APIエラーを防止

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -76,6 +76,33 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   //     fetchTasks を撃つようコアレスする
   const taskOpGenerationRef = useRef(0);
   const dragInFlightRef = useRef(0);
+  // ドラッグ大量操作時のスロットリング:
+  //   - 並列 PATCH を最大 DRAG_CONCURRENCY 件に制限し、Google Tasks API の
+  //     レート制限と並列 OAuth refresh による異常検知（unknownerror ロックアウト）を回避
+  const DRAG_CONCURRENCY = 2;
+  const dragQueueRef = useRef<Array<() => Promise<void>>>([]);
+  const dragActiveRef = useRef(0);
+  const pumpDragQueue = useCallback(() => {
+    while (
+      dragActiveRef.current < DRAG_CONCURRENCY &&
+      dragQueueRef.current.length > 0
+    ) {
+      const op = dragQueueRef.current.shift();
+      if (!op) break;
+      dragActiveRef.current++;
+      op().finally(() => {
+        dragActiveRef.current--;
+        pumpDragQueue();
+      });
+    }
+  }, []);
+  const enqueueDragOp = useCallback(
+    (op: () => Promise<void>) => {
+      dragQueueRef.current.push(op);
+      pumpDragQueue();
+    },
+    [pumpDragQueue]
+  );
   const [showSettings, setShowSettings] = useState(false);
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
   const [settings, setSettings] = useState<AppSettings>({
@@ -921,32 +948,52 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       }
     };
 
+    // PATCH 失敗時のロールバック: 移動先から除去し、元バケットに復元
+    const restoreToBucket = (tab: TabKey, original: Task) => {
+      switch (tab) {
+        case "expired":     setExpiredTasks((p) => (p.some((t) => t.id === original.id) ? p : [original, ...p])); break;
+        case "today":       setIncompleteTasks((p) => (p.some((t) => t.id === original.id) ? p : [original, ...p])); break;
+        case "tomorrow":    setTomorrowTasks((p) => (p.some((t) => t.id === original.id) ? p : [original, ...p])); break;
+        case "completed":   setCompletedTasks((p) => (p.some((t) => t.id === original.id) ? p : [original, ...p])); break;
+        case "withinWeek":  setFutureTasks((p) => ({ ...p, withinWeek: p.withinWeek.some((t) => t.id === original.id) ? p.withinWeek : [original, ...p.withinWeek] })); break;
+        case "withinMonth": setFutureTasks((p) => ({ ...p, withinMonth: p.withinMonth.some((t) => t.id === original.id) ? p.withinMonth : [original, ...p.withinMonth] })); break;
+        case "noDeadline":  setFutureTasks((p) => ({ ...p, noDeadline: p.noDeadline.some((t) => t.id === original.id) ? p.noDeadline : [original, ...p.noDeadline] })); break;
+      }
+    };
+
     removeFromBucket(from);
 
     if (dropTarget === "completed") {
       const updatedTask: Task = { ...task, status: "completed" };
       setCompletedTasks((p) => (p.some((t) => t.id === task.id) ? p : [updatedTask, ...p]));
 
-      try {
-        const res = await fetch("/api/tasks", {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ taskId: task.id, listId: task.listId, status: "completed" }),
-        });
-        if (!res.ok) throw new Error("更新に失敗しました");
+      // 並列 PATCH を制限してキュー経由で送信（バースト時の OAuth ロックと
+      // Google Tasks API レート制限を防止）
+      enqueueDragOp(async () => {
+        try {
+          const res = await fetch("/api/tasks", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ taskId: task.id, listId: task.listId, status: "completed" }),
+          });
+          if (!res.ok) throw new Error("更新に失敗しました");
 
-        addTaskHistoryItem(
-          "complete",
-          task.id,
-          task.title,
-          { ...task, status: "needsAction" },
-          updatedTask
-        );
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "エラーが発生しました");
-      } finally {
-        finalizeDragSync();
-      }
+          addTaskHistoryItem(
+            "complete",
+            task.id,
+            task.title,
+            { ...task, status: "needsAction" },
+            updatedTask
+          );
+        } catch (err) {
+          // ロールバック: completed から除去し、元バケットへ復元
+          setCompletedTasks((p) => p.filter((t) => t.id !== task.id));
+          restoreToBucket(from, task);
+          setError(err instanceof Error ? err.message : "エラーが発生しました");
+        } finally {
+          finalizeDragSync();
+        }
+      });
     } else {
       const newDue = getDueDateForCategory(dropTarget) ?? "";
       const updatedTask: Task = { ...task, due: newDue };
@@ -961,22 +1008,39 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         }
       };
 
+      // 移動先バケットからタスクを除去するヘルパー（ロールバック用）
+      const removeFromTarget = (tab: TabKey) => {
+        switch (tab) {
+          case "today":       setIncompleteTasks((p) => p.filter((t) => t.id !== task.id)); break;
+          case "tomorrow":    setTomorrowTasks((p) => p.filter((t) => t.id !== task.id)); break;
+          case "withinWeek":  setFutureTasks((p) => ({ ...p, withinWeek: p.withinWeek.filter((t) => t.id !== task.id) })); break;
+          case "withinMonth": setFutureTasks((p) => ({ ...p, withinMonth: p.withinMonth.filter((t) => t.id !== task.id) })); break;
+          case "noDeadline":  setFutureTasks((p) => ({ ...p, noDeadline: p.noDeadline.filter((t) => t.id !== task.id) })); break;
+        }
+      };
+
       addToBucket(dropTarget);
 
-      try {
-        const res = await fetch("/api/tasks", {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ taskId: task.id, listId: task.listId, due: newDue }),
-        });
-        if (!res.ok) throw new Error("期限の変更に失敗しました");
+      // 並列 PATCH を制限してキュー経由で送信
+      enqueueDragOp(async () => {
+        try {
+          const res = await fetch("/api/tasks", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ taskId: task.id, listId: task.listId, due: newDue }),
+          });
+          if (!res.ok) throw new Error("期限の変更に失敗しました");
 
-        addTaskHistoryItem("changeDue", task.id, task.title, { ...task }, updatedTask);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "エラーが発生しました");
-      } finally {
-        finalizeDragSync();
-      }
+          addTaskHistoryItem("changeDue", task.id, task.title, { ...task }, updatedTask);
+        } catch (err) {
+          // ロールバック: 移動先から除去し、元バケットへ復元
+          removeFromTarget(dropTarget);
+          restoreToBucket(from, task);
+          setError(err instanceof Error ? err.message : "エラーが発生しました");
+        } finally {
+          finalizeDragSync();
+        }
+      });
     }
   };
 


### PR DESCRIPTION
## 関連仕様Issue
- なし（バグ修正）

## 実装内容
期限切れタスクなどを大量にドラッグ＆ドロップで別カテゴリに移動すると、Google OAuth の異常検知（`accounts.google.com/info/unknownerror` ロックアウト）と Google Tasks API のレート制限エラーが発生する不具合を修正する。

### 原因
- `handleDrop` がドロップごとに即座に PATCH を発火しており、並列度の制御がなかった
- 20件などを一気にドラッグすると 20本の並列 PATCH が `/api/tasks` に到達し、サーバ側で並列に NextAuth の JWT callback が走る
- トークンが期限間近の場合、20本がそれぞれ独立に `https://oauth2.googleapis.com/token` に refresh をリクエスト
- Google が同一 client_id からの突発的な refresh 連打を異常検知し、OAuth ロックアウトに至る
- 加えて Google Tasks API のレート制限（500 q/100s/user）にも抵触し PATCH の一部が 500 で失敗

### 修正内容
**A: 並列度制限**
- `dragQueueRef` / `dragActiveRef` を追加し、`handleDrop` の PATCH をキュー経由で送信
- 同時実行を最大2件（`DRAG_CONCURRENCY = 2`）に制限
- 楽観的更新は即時実行のままなので UI 反応速度は維持

**C: PATCH 失敗時のロールバック**
- 完了ドロップ失敗時：`completedTasks` から除去 → 元バケットに復元
- 期限変更ドロップ失敗時：移動先バケットから除去 → 元バケットに復元
- 全タブ（expired/today/tomorrow/completed/withinWeek/withinMonth/noDeadline）に対応

## 変更ファイル
- `src/app/components/TaskList.tsx` — キュー機構の追加、`handleDrop` のキュー経由化、ロールバック処理の追加

## テスト手順
- [ ] 期限切れタスクを5〜20件選んで連続して別タブ（明日/今週中など）にドラッグ → エラーが出ず、すべて移動先に表示される
- [ ] 完了タブへの大量ドロップでも同様にエラーなく完了する
- [ ] DevTools Network タブで PATCH の同時実行数が最大2件に制限されていることを確認
- [ ] サーバを意図的に落とした状態でドラッグ → タスクが元のタブに復元されることを確認（ロールバック動作）
- [ ] 単体ドラッグの UI 反応速度が以前と同等であることを確認

## スクリーンショット
なし（挙動修正のみ）

## 備考
- サーバー側 NextAuth JWT callback への single-flight 機構（B案）は Vercel サーバーレスではプロセス間で共有できず効果が限定的なため見送り
- `dragInFlightRef` による fetchTasks コアレス、`taskOpGenerationRef` による in-flight GET 無効化（PR #146 で導入済み）の挙動は保持