### PR TITLE
fix: 連続ドロップ時のタスク取得失敗をAPI呼び出し削減で解消

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "auth";
-import { fetchTodayTasks, fetchExpiredTasks, fetchTodayCompletedTasks, fetchFutureTasks, fetchTomorrowTasks, createTasksApi } from "@/lib/tasks";
+import { fetchAllCategorizedTasks, createTasksApi } from "@/lib/tasks";
 
 export async function GET() {
   const session = await auth();
@@ -10,14 +10,8 @@ export async function GET() {
   }
 
   try {
-    const [todayTasks, expiredTasks, completedTasks, futureTasks, tomorrowTasks] = await Promise.all([
-      fetchTodayTasks(session.accessToken as string),
-      fetchExpiredTasks(session.accessToken as string),
-      fetchTodayCompletedTasks(session.accessToken as string),
-      fetchFutureTasks(session.accessToken as string),
-      fetchTomorrowTasks(session.accessToken as string),
-    ]);
-    return NextResponse.json({ todayTasks, expiredTasks, completedTasks, futureTasks, tomorrowTasks });
+    const categorized = await fetchAllCategorizedTasks(session.accessToken as string);
+    return NextResponse.json(categorized);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("Google Tasks API error:", message);

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -74,8 +74,13 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   //     入った時点で in-flight の GET レスポンスを無効化する
   //   - dragInFlightRef: 進行中のドロップ PATCH 数。バースト中は最後の1回だけ
   //     fetchTasks を撃つようコアレスする
+  //   - fetchInFlightRef / fetchPendingRef: GET /api/tasks の並走防止。in-flight 中に
+  //     再要求が来たら pending フラグを立て、完了直後に1回だけ追加実行する。
+  //     これにより Google Tasks API のレート制限ヒットを抑える。
   const taskOpGenerationRef = useRef(0);
   const dragInFlightRef = useRef(0);
+  const fetchInFlightRef = useRef(false);
+  const fetchPendingRef = useRef(false);
   // ドラッグ大量操作時のスロットリング:
   //   - 並列 PATCH を最大 DRAG_CONCURRENCY 件に制限し、Google Tasks API の
   //     レート制限と並列 OAuth refresh による異常検知（unknownerror ロックアウト）を回避
@@ -245,8 +250,15 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   const filteredTaskListsForCurrentTab = getFilteredTaskListsForCurrentTab();
 
   const fetchTasks = useCallback(async () => {
-    // 世代番号: 同時に複数の fetchTasks が in-flight になった場合、
-    // または fetchTasks 中に新たなドロップ等が入った場合、
+    // 既に GET /api/tasks が in-flight の場合は新規発行せず、pending フラグだけ立てる。
+    // 完了後に必要なら1回だけ追加実行することで、複数の重い GET が並走して
+    // Google Tasks API のレート制限を引き起こすのを防ぐ。
+    if (fetchInFlightRef.current) {
+      fetchPendingRef.current = true;
+      return;
+    }
+    fetchInFlightRef.current = true;
+    // 世代番号: fetchTasks 中に新たなドロップ等が入った場合、
     // 古いレスポンスでローカル状態を上書きしないようガードする
     const gen = ++taskOpGenerationRef.current;
     setLoading(true);
@@ -272,6 +284,12 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
       setError(e instanceof Error ? e.message : "エラーが発生しました");
     } finally {
       if (gen === taskOpGenerationRef.current) setLoading(false);
+      fetchInFlightRef.current = false;
+      if (fetchPendingRef.current) {
+        fetchPendingRef.current = false;
+        // 次のマイクロタスクで再実行（バースト中の最終状態に同期させる）
+        setTimeout(() => fetchTasks(), 0);
+      }
     }
   }, []);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { auth } from "auth";
 import { redirect } from "next/navigation";
-import { fetchTodayTasks, fetchExpiredTasks, fetchTodayCompletedTasks, fetchFutureTasks, fetchTomorrowTasks } from "@/lib/tasks";
+import { fetchAllCategorizedTasks } from "@/lib/tasks";
 import TaskList from "@/app/components/TaskList";
 import LoginButton from "@/app/components/LoginButton";
 
@@ -17,15 +17,9 @@ export default async function Home() {
     redirect("/api/auth/signin?provider=google");
   }
 
-  let tasks, expiredTasks, completedTasks, futureTasks, tomorrowTasks;
+  let categorized;
   try {
-    [tasks, expiredTasks, completedTasks, futureTasks, tomorrowTasks] = await Promise.all([
-      fetchTodayTasks(session.accessToken as string),
-      fetchExpiredTasks(session.accessToken as string),
-      fetchTodayCompletedTasks(session.accessToken as string),
-      fetchFutureTasks(session.accessToken as string),
-      fetchTomorrowTasks(session.accessToken as string),
-    ]);
+    categorized = await fetchAllCategorizedTasks(session.accessToken as string);
   } catch (err: unknown) {
     const status = (err as { status?: number; code?: number })?.status ?? (err as { status?: number; code?: number })?.code;
     if (status === 403) {
@@ -35,5 +29,6 @@ export default async function Home() {
     throw err;
   }
 
-  return <TaskList initialTasks={tasks} initialExpiredTasks={expiredTasks} initialCompletedTasks={completedTasks} initialFutureTasks={futureTasks} initialTomorrowTasks={tomorrowTasks} user={session.user} />;
+  const { todayTasks, expiredTasks, completedTasks, futureTasks, tomorrowTasks } = categorized;
+  return <TaskList initialTasks={todayTasks} initialExpiredTasks={expiredTasks} initialCompletedTasks={completedTasks} initialFutureTasks={futureTasks} initialTomorrowTasks={tomorrowTasks} user={session.user} />;
 }

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -30,13 +30,12 @@ export function createTasksApi(accessToken: string) {
 
 type TasksApi = ReturnType<typeof createTasksApi>;
 
-/** 全タスクリストの items を一括取得する */
-async function fetchAllTaskItems(
+/** 与えられたタスクリスト群について tasks.list を並列発行する */
+async function fetchListItemsForLists(
   tasksApi: TasksApi,
+  lists: RawList[],
   options: { showCompleted?: boolean; showHidden?: boolean } = {}
 ): Promise<Array<{ list: RawList; items: RawTask[] }>> {
-  const listsRes = await tasksApi.tasklists.list({ maxResults: 100 });
-  const lists = listsRes.data.items ?? [];
   return Promise.all(
     lists.map((list) =>
       tasksApi.tasks
@@ -46,7 +45,7 @@ async function fetchAllTaskItems(
           showCompleted: options.showCompleted ?? false,
           ...(options.showHidden ? { showHidden: true } : {}),
         })
-        .then((res) => ({ list: list as RawList, items: (res.data.items ?? []) as RawTask[] }))
+        .then((res) => ({ list, items: (res.data.items ?? []) as RawTask[] }))
     )
   );
 }
@@ -64,110 +63,98 @@ function toTask(task: RawTask, list: RawList, dueFallback = ""): Task {
   };
 }
 
-export async function fetchTodayTasks(accessToken: string): Promise<Task[]> {
-  const tasksApi = createTasksApi(accessToken);
-  const allTasksResults = await fetchAllTaskItems(tasksApi);
-  const todayStr = getTodayJST();
-  const result: Task[] = [];
-  for (const { list, items } of allTasksResults) {
-    for (const task of items) {
-      if (task.due?.slice(0, 10) === todayStr) {
-        result.push(toTask(task, list));
-      }
-    }
-  }
-  return result;
-}
+export type CategorizedTasks = {
+  todayTasks: Task[];
+  expiredTasks: Task[];
+  completedTasks: Task[];
+  tomorrowTasks: Task[];
+  futureTasks: {
+    withinWeek: Task[];
+    withinMonth: Task[];
+    noDeadline: Task[];
+  };
+};
 
-export async function fetchExpiredTasks(accessToken: string): Promise<Task[]> {
+/**
+ * 1 回のタスクリスト一覧取得 + 2 セット（未完了 / 当日完了向け）の tasks.list で
+ * 全カテゴリのタスクをまとめて取得・分類する。
+ *
+ * 旧実装は分類ごとに fetchAllTaskItems を 5 回呼んでおり、リスト数 N に対し
+ * `5 + 5N` 件の Google Tasks API 並列呼び出しが発生してレート制限に
+ * ぶつかりやすかった。本関数は `1 + 2N` 件まで削減する。
+ */
+export async function fetchAllCategorizedTasks(accessToken: string): Promise<CategorizedTasks> {
   const tasksApi = createTasksApi(accessToken);
-  const allTasksResults = await fetchAllTaskItems(tasksApi);
-  const todayStr = getTodayJST();
-  const result: Task[] = [];
-  for (const { list, items } of allTasksResults) {
-    for (const task of items) {
-      if (task.due && task.due.slice(0, 10) < todayStr) {
-        result.push(toTask(task, list));
-      }
-    }
-  }
-  return result;
-}
+  const listsRes = await tasksApi.tasklists.list({ maxResults: 100 });
+  const lists = (listsRes.data.items ?? []) as RawList[];
 
-export async function fetchTomorrowTasks(accessToken: string): Promise<Task[]> {
-  const tasksApi = createTasksApi(accessToken);
-  const allTasksResults = await fetchAllTaskItems(tasksApi);
-  const todayStr = getTodayJST();
-  const tomorrowStr = new Date(new Date(todayStr).getTime() + 86400000).toLocaleDateString("sv-SE", {
-    timeZone: "Asia/Tokyo",
-  });
-  const result: Task[] = [];
-  for (const { list, items } of allTasksResults) {
-    for (const task of items) {
-      if (task.due?.slice(0, 10) === tomorrowStr) {
-        result.push(toTask(task, list));
-      }
-    }
-  }
-  return result;
-}
+  const [activeResults, completedResults] = await Promise.all([
+    fetchListItemsForLists(tasksApi, lists, { showCompleted: false }),
+    fetchListItemsForLists(tasksApi, lists, { showCompleted: true, showHidden: true }),
+  ]);
 
-export async function fetchFutureTasks(accessToken: string): Promise<{
-  withinWeek: Task[];
-  withinMonth: Task[];
-  noDeadline: Task[];
-}> {
-  const tasksApi = createTasksApi(accessToken);
-  const allTasksResults = await fetchAllTaskItems(tasksApi);
   const todayStr = getTodayJST();
   const today = new Date(todayStr);
   const tomorrow = new Date(today.getTime() + 86400000);
+  const tomorrowStr = tomorrow.toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
   const oneWeekFromNow = new Date(today.getTime() + 7 * 86400000);
 
+  const todayTasks: Task[] = [];
+  const expiredTasks: Task[] = [];
+  const tomorrowTasks: Task[] = [];
   const withinWeek: Task[] = [];
   const withinMonth: Task[] = [];
   const noDeadline: Task[] = [];
 
-  for (const { list, items } of allTasksResults) {
-    for (const task of items) {
-      if (task.due && task.status !== "completed") {
-        const taskDate = new Date(task.due.slice(0, 10));
+  for (const { list, items } of activeResults) {
+    for (const t of items) {
+      if (t.status === "completed") continue;
+      const dueDay = t.due?.slice(0, 10);
+      if (!dueDay) {
+        noDeadline.push(toTask(t, list, ""));
+      } else if (dueDay < todayStr) {
+        expiredTasks.push(toTask(t, list));
+      } else if (dueDay === todayStr) {
+        todayTasks.push(toTask(t, list));
+      } else if (dueDay === tomorrowStr) {
+        tomorrowTasks.push(toTask(t, list));
+      } else {
+        const taskDate = new Date(dueDay);
         if (taskDate > tomorrow) {
-          const taskObj = toTask(task, list);
+          const taskObj = toTask(t, list);
           if (taskDate <= oneWeekFromNow) {
             withinWeek.push(taskObj);
           } else {
             withinMonth.push(taskObj);
           }
         }
-      } else if (task.status !== "completed") {
-        noDeadline.push(toTask(task, list, ""));
+      }
+    }
+  }
+
+  const completedTasks: Task[] = [];
+  for (const { list, items } of completedResults) {
+    for (const t of items) {
+      if (t.status === "completed" && t.completed) {
+        const completedDate = new Date(t.completed).toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+        if (completedDate === todayStr) {
+          completedTasks.push(toTask(t, list, ""));
+        }
       }
     }
   }
 
   const byDue = (a: Task, b: Task) => new Date(a.due).getTime() - new Date(b.due).getTime();
-  return {
-    withinWeek: withinWeek.sort(byDue),
-    withinMonth: withinMonth.sort(byDue),
-    noDeadline,
-  };
-}
 
-export async function fetchTodayCompletedTasks(accessToken: string): Promise<Task[]> {
-  const tasksApi = createTasksApi(accessToken);
-  const allTasksResults = await fetchAllTaskItems(tasksApi, { showCompleted: true, showHidden: true });
-  const todayStr = getTodayJST();
-  const result: Task[] = [];
-  for (const { list, items } of allTasksResults) {
-    for (const task of items) {
-      if (task.status === "completed" && task.completed) {
-        const completedDate = new Date(task.completed).toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
-        if (completedDate === todayStr) {
-          result.push(toTask(task, list, ""));
-        }
-      }
-    }
-  }
-  return result;
+  return {
+    todayTasks,
+    expiredTasks,
+    completedTasks,
+    tomorrowTasks,
+    futureTasks: {
+      withinWeek: withinWeek.sort(byDue),
+      withinMonth: withinMonth.sort(byDue),
+      noDeadline,
+    },
+  };
 }


### PR DESCRIPTION
## 関連仕様Issue
- なし（バグ修正）

## 実装内容
複数タスクを連続でドラッグ&ドロップした際に「タスクの取得に失敗しました」エラーが再発する不具合を修正。

### 根本原因
`GET /api/tasks` が内部で `fetchAllTaskItems` を **5 セット並列**で発行しており、タスクリスト数 N に対して **`5 + 5N` 件**の Google Tasks API 呼び出しが同時に走っていた（リスト 10 個で約 55 並列）。連続ドロップ後の fetch でレート制限 / OAuth 異常検知に達し、500 エラー → 汎用メッセージ表示につながっていた。

加えてクライアント側の `fetchTasks` に並走防止が無く、PATCH 完了 → fetchTasks → 次ドロップ完了 → fetchTasks で重い GET が並走していた。

## 変更ファイル
- `src/lib/tasks.ts`: 1 回の `tasklists.list` + 2 セットの `tasks.list` で全カテゴリを分類する `fetchAllCategorizedTasks` を新設。旧 5 関数（`fetchTodayTasks` 等）を削除。並列呼び出し数を **`5 + 5N` → `1 + 2N`** に削減。
- `src/app/api/tasks/route.ts`: GET を新関数に置き換え。
- `src/app/page.tsx`: SSR を新関数に置き換え。
- `src/app/components/TaskList.tsx`: `fetchTasks` に in-flight ガード（`fetchInFlightRef` / `fetchPendingRef`）を追加。バースト中は最後の状態に 1 回だけ同期する。

## テスト手順
- [ ] 本日の未完了タスクから明日のタスクへ複数タスクを連続ドラッグ&ドロップしてエラーが出ないこと
- [ ] 本日の未完了タスクから一週間以内へ複数タスクを連続ドラッグ&ドロップしてエラーが出ないこと
- [ ] 期限切れタスクから別カテゴリへ大量にドラッグ&ドロップしてもロックアウトされないこと
- [ ] 単一タスクのドロップ動作が従来どおり機能すること
- [ ] 完了ドロップ（completed カラム）でも問題なく動作すること
- [ ] ページロード時の初期データ表示が正しいこと（今日／期限切れ／完了／明日／一週間以内／一ヶ月以内／期限なし）

## スクリーンショット
なし

## 備考
- TypeScript チェック (`tsc --noEmit`) / Next.js ビルドともに通過済み。
- Vercel デプロイ後、実機で連続ドロップ動作を確認してください。
- 万一エラーが再発する場合は Vercel logs の `Google Tasks API error:` 行（実際の Google API メッセージ）を共有してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)