### PR TITLE
fix: タスク編集後の画面反映を楽観的更新で高速化

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -710,13 +710,76 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   };
 
   const updateTask = async (task: Task, title: string, notes: string, due: string, newListId?: string) => {
+    // 楽観的更新: 編集内容を即座にローカル状態へ反映する。
+    // fetchTasks は Google Tasks API を 1+2N 回叩く重い処理のため、
+    // 完了待ちで UI 反映を遅らせず、バックグラウンドで sync する。
+    const resolvedListId = newListId ?? task.listId;
+    const resolvedListTitle = newListId
+      ? taskLists.find((l) => l.id === newListId)?.title ?? task.listTitle
+      : task.listTitle;
+    const updatedTask: Task = {
+      ...task,
+      title,
+      notes,
+      due,
+      listId: resolvedListId,
+      listTitle: resolvedListTitle,
+    };
+
+    // 全バケットから既存タスクを除去
+    setIncompleteTasks((prev) => prev.filter((t) => t.id !== task.id));
+    setExpiredTasks((prev) => prev.filter((t) => t.id !== task.id));
+    setTomorrowTasks((prev) => prev.filter((t) => t.id !== task.id));
+    setCompletedTasks((prev) => prev.filter((t) => t.id !== task.id));
+    setFutureTasks((prev) => ({
+      withinWeek: prev.withinWeek.filter((t) => t.id !== task.id),
+      withinMonth: prev.withinMonth.filter((t) => t.id !== task.id),
+      noDeadline: prev.noDeadline.filter((t) => t.id !== task.id),
+    }));
+
+    // 新しい due/status に基づいて適切なバケットへ追加
+    // 振り分け条件は tasks.ts のサーバー側と揃える
+    if (updatedTask.status === "completed") {
+      setCompletedTasks((prev) => prev.some((t) => t.id === task.id) ? prev : [updatedTask, ...prev]);
+    } else {
+      const todayStr = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+      const today = new Date(todayStr);
+      const tomorrowStr = new Date(today.getTime() + 24 * 60 * 60 * 1000)
+        .toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+      const oneWeekFromNow = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+      const dueDateStr = updatedTask.due ? updatedTask.due.slice(0, 10) : "";
+      if (dueDateStr === "") {
+        setFutureTasks((prev) => ({
+          ...prev,
+          noDeadline: prev.noDeadline.some((t) => t.id === task.id) ? prev.noDeadline : [updatedTask, ...prev.noDeadline],
+        }));
+      } else if (dueDateStr < todayStr) {
+        setExpiredTasks((prev) => prev.some((t) => t.id === task.id) ? prev : [updatedTask, ...prev]);
+      } else if (dueDateStr === todayStr) {
+        setIncompleteTasks((prev) => prev.some((t) => t.id === task.id) ? prev : [updatedTask, ...prev]);
+      } else if (dueDateStr === tomorrowStr) {
+        setTomorrowTasks((prev) => prev.some((t) => t.id === task.id) ? prev : [updatedTask, ...prev]);
+      } else if (new Date(dueDateStr) <= oneWeekFromNow) {
+        setFutureTasks((prev) => ({
+          ...prev,
+          withinWeek: prev.withinWeek.some((t) => t.id === task.id) ? prev.withinWeek : [updatedTask, ...prev.withinWeek],
+        }));
+      } else {
+        setFutureTasks((prev) => ({
+          ...prev,
+          withinMonth: prev.withinMonth.some((t) => t.id === task.id) ? prev.withinMonth : [updatedTask, ...prev.withinMonth],
+        }));
+      }
+    }
+
     try {
       const res = await fetch("/api/tasks", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ 
-          taskId: task.id, 
-          listId: task.listId, 
+        body: JSON.stringify({
+          taskId: task.id,
+          listId: task.listId,
           title: title,
           notes: notes,
           due: due,
@@ -726,10 +789,10 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
 
       if (!res.ok) throw new Error("タスクの更新に失敗しました");
 
-      // タスクの更新履歴を記録
+      // タスクの更新履歴を記録（PATCH 成功直後、sync より先に）
       const hasContentChange = task.title !== title || task.notes !== notes;
       const hasDueChange = task.due !== due;
-      
+
       if (hasContentChange) {
         addTaskHistoryItem(
           "edit",
@@ -739,7 +802,7 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
           { ...task, title, notes } // 変更後の状態
         );
       }
-      
+
       if (hasDueChange) {
         addTaskHistoryItem(
           "changeDue",
@@ -750,10 +813,12 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         );
       }
 
-      // タスクリストを再取得
-      await fetchTasks();
+      // バックグラウンドでサーバー同期（UI は楽観的更新済みなので await しない）
+      fetchTasks();
     } catch (e) {
       setError(e instanceof Error ? e.message : "エラーが発生しました");
+      // 失敗時はサーバー状態に戻す
+      fetchTasks();
       throw e;
     }
   };


### PR DESCRIPTION
## 関連仕様Issue
- なし（パフォーマンス改善）

## 実装内容
タスク編集モーダルの保存後、画面に編集内容（タイトル・詳細・期限・リスト変更）が反映されるまで `fetchTasks` の完了を待つ実装になっていた。`fetchTasks` は内部で Google Tasks API を `1 + 2N`（N = リスト数）回呼ぶ重い処理のため、リストが数本ある状態で 1〜2 秒の遅延が体感されていた。

`updateTask` を、同ファイル内の `completeTask` / `uncompleteTask` と同じ「楽観的更新 → PATCH → バックグラウンド sync」パターンへ統一した。

- 編集後の `updatedTask` を作って全バケット（incomplete/expired/tomorrow/completed/futureTasks）から旧タスクを除去
- 新しい `due` / `status` に応じて適切なバケット（`expired` / `today` / `tomorrow` / `withinWeek` / `withinMonth` / `noDeadline`）へ即座に追加。リスト変更時は `taskLists` から `listTitle` を解決して反映
- PATCH 成功後に履歴記録 → `fetchTasks()` は **await せずバックグラウンド sync**
- PATCH 失敗時は `setError` + `fetchTasks()` でサーバー状態へロールバック

振り分け条件（`todayStr` / `tomorrowStr` / `oneWeekFromNow`、JST 基準）は `tasks.ts` のサーバー側および `uncompleteTask` と同一の式を使用。

## 変更ファイル
- `src/app/components/TaskList.tsx` — `updateTask` を楽観的更新パターンへ書き換え

## テスト手順
- [ ] タスクのタイトル/詳細のみ変更 → モーダルを閉じた瞬間にカード表示が更新される
- [ ] 期限日を「今日 → 明日」「今日 → 1週間以内」「期限あり → 期限なし」へ変更 → 適切なタブへ即座に移動する
- [ ] タスク種別（リスト）を変更 → モーダルを閉じた瞬間に `listTitle` が反映される
- [ ] サーバーエラー（DevTools でネットワーク Offline）→ エラーメッセージ表示 + 再フェッチで元の状態へ戻る
- [ ] 編集後、数秒待ってもタスクが重複表示・消失しない（バックグラウンド sync 完了後も整合性が保たれる）

## スクリーンショット
（パフォーマンス改善のため省略）

## 備考
- `fetchTasks` の in-flight guard（`fetchInFlightRef` / `fetchPendingRef`）は既存のままなので、編集直後に別操作が走ってもレート制限ヒットの懸念はない
- 振り分け条件式はサーバー側と同じものをコピーしている。将来的に共通ユーティリティへ切り出すのは別タスクで対応する想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)