### PR TITLE
feat: Chrome 拡張から API を叩けるよう CORS proxy と Cookie 設定を追加

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -1,8 +1,25 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 
+// 本番では Chrome 拡張からのクロスサイト送信を許可するため SameSite=None; Secure を強制する。
+// 開発（http://localhost）では Secure=true だと Cookie が発行されないため Lax を維持する。
+const useCrossSite = process.env.NODE_ENV === "production";
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   secret: process.env.AUTH_SECRET,
+  cookies: {
+    sessionToken: {
+      name: useCrossSite
+        ? "__Secure-authjs.session-token"
+        : "authjs.session-token",
+      options: {
+        httpOnly: true,
+        sameSite: useCrossSite ? "none" : "lax",
+        path: "/",
+        secure: useCrossSite,
+      },
+    },
+  },
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+// 許可する Chrome 拡張オリジン。Vercel/環境変数 CHROME_EXTENSION_IDS に
+// カンマ区切りで複数 ID を登録できる（例: "abcdefgh...,ijklmnop..."）。
+const allowedExtensionIds = (process.env.CHROME_EXTENSION_IDS ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const allowedOrigins = new Set(
+  allowedExtensionIds.map((id) => `chrome-extension://${id}`)
+);
+
+function corsHeaders(origin: string): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
+  };
+}
+
+export function proxy(request: NextRequest) {
+  const origin = request.headers.get("origin") ?? "";
+  const isAllowed = origin !== "" && allowedOrigins.has(origin);
+
+  if (request.method === "OPTIONS") {
+    if (!isAllowed) {
+      return new NextResponse(null, { status: 403 });
+    }
+    return new NextResponse(null, { status: 204, headers: corsHeaders(origin) });
+  }
+
+  const response = NextResponse.next();
+  if (isAllowed) {
+    for (const [key, value] of Object.entries(corsHeaders(origin))) {
+      response.headers.set(key, value);
+    }
+  }
+  return response;
+}
+
+export const config = {
+  matcher: "/api/tasks/:path*",
+};


### PR DESCRIPTION
## 関連仕様Issue
<!-- 仕様Issueは未作成。Chrome 拡張プロジェクトの追加に伴う Web 側対応 -->
- なし

## 実装内容

別リポジトリで新規作成する Chrome 拡張（コンパニオン拡張）から、本 Web アプリの API を Cookie 共有で叩けるようにする。

### 変更点

- **auth.ts**: 本番のみ NextAuth セッション Cookie を ``SameSite=None; Secure`` に変更（開発環境は ``Lax`` を維持）
- **src/proxy.ts** (新規): Next.js 16 の新ミドルウェア。``/api/tasks/*`` に CORS ヘッダーを付与。許可オリジンは環境変数 ``CHROME_EXTENSION_IDS`` で構成

## 変更ファイル

- ``auth.ts`` — Cookie の SameSite/Secure 属性を環境ごとに切り替え
- ``src/proxy.ts`` — Chrome 拡張オリジンのみを許可する CORS proxy

## デプロイ前の準備

Vercel に環境変数 ``CHROME_EXTENSION_IDS`` を追加（カンマ区切りで複数 ID 可）してください。
未設定の場合は誰も許可されず、現状の Web UI には影響ありません。

## 影響

- 既存ユーザーは Cookie 名が変わるため一度ログアウトされ、再ログインが必要
- ``/api/auth/*`` は CORS 対象外で、拡張からは叩かない設計

## テスト手順

- [ ] Vercel に ``CHROME_EXTENSION_IDS`` を設定してデプロイ
- [ ] 既存の Web UI で再ログイン → 通常通り操作できる
- [ ] Chrome 拡張側で popup を開き、``GET /api/tasks`` が 200 で返る
- [ ] Network タブで ``Access-Control-Allow-Origin: chrome-extension://<id>`` が付与されている

## 備考

ローカルで拡張から叩く場合は ``next dev --experimental-https`` が必要（``SameSite=None`` の Cookie は ``Secure`` 必須のため）。