### PR TITLE
fix: 設定画面に新規作成リストが表示されない問題を修正

### DIFF
--- a/src/app/components/SettingsModal.tsx
+++ b/src/app/components/SettingsModal.tsx
@@ -10,9 +10,17 @@ interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   allTasks?: Task[];
+  taskLists?: { id: string; title: string }[];
+  onRefreshTaskLists?: () => void | Promise<void>;
 }
 
-export default function SettingsModal({ isOpen, onClose, allTasks = [] }: SettingsModalProps) {
+export default function SettingsModal({
+  isOpen,
+  onClose,
+  allTasks = [],
+  taskLists = [],
+  onRefreshTaskLists,
+}: SettingsModalProps) {
   const [settings, setSettings] = useState<AppSettings>({
     showUserName: true,
     visibleLists: {
@@ -38,6 +46,12 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
       setSettings(getSettings());
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      onRefreshTaskLists?.();
+    }
+  }, [isOpen, onRefreshTaskLists]);
 
   const handleSave = () => {
     const settingsToSave = {
@@ -189,8 +203,12 @@ export default function SettingsModal({ isOpen, onClose, allTasks = [] }: Settin
   };
 
   // 利用可能なカテゴリー一覧を取得
+  // マスターデータ（taskLists）を主軸にし、allTasks 由来の値もフォールバックとしてマージする
   const availableCategories = Array.from(
-    new Set(allTasks.map(task => task.listTitle).filter(Boolean))
+    new Set([
+      ...taskLists.map(list => list.title).filter(Boolean),
+      ...allTasks.map(task => task.listTitle).filter(Boolean),
+    ])
   ).sort();
 
   if (!isOpen) return null;

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -1980,8 +1980,8 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
         )}
       </main>
       
-      <SettingsModal 
-        isOpen={showSettings} 
+      <SettingsModal
+        isOpen={showSettings}
         onClose={() => {
           setShowSettings(false);
           refreshSettings();
@@ -1995,6 +1995,8 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
           ...futureTasks.withinMonth,
           ...futureTasks.noDeadline,
         ]}
+        taskLists={taskLists}
+        onRefreshTaskLists={fetchTaskLists}
       />
       
       {selectedTask && (


### PR DESCRIPTION
## 関連仕様Issue
- なし（バグ修正）

## 実装内容
設定モーダルのカテゴリー一覧が「現在表示中のタスクからの逆引き」で生成されており、タスクが 0 件の新規作成リストが表示されない問題を修正。

- `SettingsModal` に `taskLists` / `onRefreshTaskLists` props を追加し、マスターデータ（`/api/tasks/lists` 由来）を直接参照する形に変更
- `availableCategories` は `taskLists.title`（主）と `allTasks.listTitle`（フォールバック）の和集合で生成
- モーダル open 時に `onRefreshTaskLists()` を呼び、Google Tasks Web/モバイルで作成した直後でも reload なしで反映されるようにする

これは `common/.claude/rules/tech-react.md` で文書化されている「選択肢リストは表示データからの逆引きではなくマスターデータを直接参照する」アンチパターンの再発で、その教訓どおりに修正した。

## 変更ファイル
- `src/app/components/SettingsModal.tsx` — props 追加 / 再取得 useEffect / `availableCategories` のロジック変更
- `src/app/components/TaskList.tsx` — `<SettingsModal>` に `taskLists` と `fetchTaskLists` を渡す

## テスト手順
- [ ] `npm run dev` で起動
- [ ] 別タブで Google Tasks（tasks.google.com）を開き、新しいリストを作成（タスクは追加しない）
- [ ] 本アプリで「設定」を開く → カテゴリー一覧に新しいリストが表示される（**reload 不要**）
- [ ] 既存リストもすべて表示されている（リグレッションなし）
- [ ] 新規リストにタスクを 1 件追加して再度設定を開き、重複表示されないこと
- [ ] ネットワークタブで設定モーダル開閉のたびに `/api/tasks/lists` が 1 回だけ呼ばれること（再取得ループなし）

## スクリーンショット
（必要に応じて添付）

## 備考
- `npx tsc --noEmit` でエラーなしを確認済み
- 設定モーダル以外で同様の逆引きパターンが残っていないかの横展開チェックは別タスク

🤖 Generated with [Claude Code](https://claude.com/claude-code)