### PR TITLE
feat: タスクリストの notes 内 URL をタップ可能にする

### DIFF
--- a/src/app/components/TaskCard.tsx
+++ b/src/app/components/TaskCard.tsx
@@ -2,6 +2,7 @@
 
 import type { Task } from "@/lib/tasks";
 import { getTodayJST, getFirstLineOfNotes, hasTime, formatDateTime } from "@/lib/dateUtils";
+import { renderTextWithLinks } from "@/lib/linkify";
 
 export type TaskCardVariant =
   | "expired"
@@ -193,7 +194,9 @@ export default function TaskCard({
           {task.title}
         </p>
         {!isCompleted && getFirstLineOfNotes(task.notes) && (
-          <p className={`${s.notes} text-sm mt-1 truncate`}>{getFirstLineOfNotes(task.notes)}</p>
+          <p className={`${s.notes} text-sm mt-1 truncate`}>
+            {renderTextWithLinks(getFirstLineOfNotes(task.notes))}
+          </p>
         )}
         {badges}
       </div>

--- a/src/app/components/TaskDetail.tsx
+++ b/src/app/components/TaskDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import type { Task } from "@/lib/tasks";
+import { renderTextWithLinks } from "@/lib/linkify";
 
 type TaskDetailProps = {
   task: Task;
@@ -9,40 +10,6 @@ type TaskDetailProps = {
   position?: { x: number; y: number };
   onClose: () => void;
   isMobile?: boolean;
-};
-
-// URLパターンを検出する正規表現
-const URL_PATTERN = /(https?:\/\/[^\s]+)/g;
-
-// テキスト内のURLをリンクに変換する関数
-const renderTextWithLinks = (text: string, isMobile: boolean = false) => {
-  if (!text) return text;
-
-  const parts = text.split(URL_PATTERN);
-  return parts.map((part, index) => {
-    if (part.match(URL_PATTERN)) {
-      return (
-        <a
-          key={index}
-          href={part}
-          target={isMobile ? "_self" : "_blank"}
-          rel="noopener noreferrer"
-          className="text-blue-600 hover:text-blue-800 underline break-all"
-          onClick={(e) => {
-            e.stopPropagation();
-            if (isMobile) {
-              // モバイルではブラウザで開く
-              window.open(part, '_blank');
-              e.preventDefault();
-            }
-          }}
-        >
-          {part}
-        </a>
-      );
-    }
-    return part;
-  });
 };
 
 export default function TaskDetail({ task, isVisible, position, onClose, isMobile = false }: TaskDetailProps) {
@@ -118,7 +85,7 @@ export default function TaskDetail({ task, isVisible, position, onClose, isMobil
           <div className="p-4 overflow-y-auto max-h-64">
             <h4 className="font-medium text-gray-800 mb-2 break-words">{task.title}</h4>
             <div className="text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-words">
-              {renderTextWithLinks(task.notes, true)}
+              {renderTextWithLinks(task.notes)}
             </div>
           </div>
         </div>

--- a/src/lib/linkify.tsx
+++ b/src/lib/linkify.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+const URL_PATTERN = /(https?:\/\/[^\s]+)/g;
+
+export function renderTextWithLinks(text: string | undefined): ReactNode {
+  if (!text) return text ?? "";
+
+  const parts = text.split(URL_PATTERN);
+  return parts.map((part, index) => {
+    if (part.match(URL_PATTERN)) {
+      return (
+        <a
+          key={index}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:text-blue-800 underline break-all"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {part}
+        </a>
+      );
+    }
+    return part;
+  });
+}


### PR DESCRIPTION
## 関連仕様Issue
- なし（軽微なUX改善のため仕様Issueなし）

## 実装内容
タスクリスト（`TaskCard`）の notes 1行目を plain text で描画していたため、URL を含むタスクでも詳細パネルを開かないとリンクに飛べなかった。`TaskDetail` で既に使われていた URL → `<a>` 変換処理を `src/lib/linkify.tsx` に共通化し、`TaskCard` からも利用するようにした。

- リンク click 時は `e.stopPropagation()` でカードクリック（詳細パネル展開）の伝播を止める
- `target="_blank"` に統一して PC・モバイル両方で新しいタブに遷移する
- `truncate` の `white-space: nowrap` が `<a>` の `break-all` を上書きするため、長い URL もはみ出さず省略表示される

## 変更ファイル
- `src/lib/linkify.tsx`（新規）: `renderTextWithLinks` を共通ユーティリティとして切り出し
- `src/app/components/TaskCard.tsx`: notes 1行目を `renderTextWithLinks` 経由で描画
- `src/app/components/TaskDetail.tsx`: ローカル定義を削除して共通ユーティリティを import、`isMobile` 引数を呼び出し側から除去

## テスト手順
- [ ] URL を含む notes を持つタスクを作成する（例: `要件確認 https://example.com/spec`）
- [ ] リスト画面で URL 部分が青色下線付きで表示されることを確認
- [ ] URL 部分をクリック/タップして別タブで該当ページが開くことを確認
- [ ] URL 部分をクリックしてもタスク詳細パネルが開かないことを確認（伝播停止）
- [ ] URL 以外のテキスト部分をクリックすると従来通り詳細パネルが開くことを確認
- [ ] 長い URL でも `truncate` でカード幅を超えず1行に収まることを確認
- [ ] 完了済みタスクには notes 行自体が表示されないことを確認（既存挙動が保たれている）
- [ ] PC / モバイル両ビューポートで上記を確認

## スクリーンショット
（UIキャプチャはレビュー時に追加）

## 備考
- Markdown 記法 (`[text](url)`)、メールアドレス、電話番号のリンク化は対象外（既存仕様を踏襲し `https?://` で始まる素の URL のみ）
- `TaskDetail` の `renderTextWithLinks` 既存実装では `isMobile` 分岐で `_self` + `window.open` を行っていたが、両環境とも最終的に新規タブで開く挙動だったため `target="_blank"` に統一した

🤖 Generated with [Claude Code](https://claude.com/claude-code)