### PR TITLE
fix: タスク追加の種別欄に種別フィルタ設定を反映する

### DIFF
--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -238,8 +238,10 @@ export default function TaskList({ initialTasks, initialExpiredTasks, initialCom
   const getFilteredTaskListsForCurrentTab = () => {
     const activeFilterSet = getActiveFilterSet(settings);
 
-    // ALLタブ（デフォルト）またはカテゴリー設定がない場合はすべてのタスクリストを返す
-    if (activeFilterSet.isDefault || Object.keys(activeFilterSet.categories).length === 0) {
+    // カテゴリー設定がない場合はすべてのタスクリストを返す
+    // （isDefault でもカテゴリーが OFF にされていれば反映する。
+    //   filterTasksByCategory と同一条件にして表示タスクと種別ドロップダウンの挙動を揃える）
+    if (!activeFilterSet || Object.keys(activeFilterSet.categories).length === 0) {
       return taskLists;
     }
 


### PR DESCRIPTION
## 関連仕様Issue
- なし（不具合修正）

## 実装内容
設定の「表示するタスクの種別」でチェックを変更しても、タスク追加モーダルの種別ドロップダウンに反映されない不具合を修正しました。

メインのタスク一覧フィルタ（`filterTasksByCategory`）はデフォルト("ALL")フィルターセットでもカテゴリーのON/OFFを反映していましたが、タスク追加の種別ドロップダウン（`getFilteredTaskListsForCurrentTab`）は `activeFilterSet.isDefault` のとき無条件に全種別を返しており、両者の挙動がズレていました。`isDefault` 特例分岐を削除し、カテゴリー設定ベースの同一条件に統一しています。

## 変更ファイル
- `src/app/components/TaskList.tsx` — `getFilteredTaskListsForCurrentTab` の `isDefault` 特例分岐を削除し、`filterTasksByCategory` と同一のカテゴリー判定に統一

## テスト手順
- [ ] デフォルト("ALL")セットのまま、設定 → 「表示するタスクの種別」で一部の種別をOFFにして保存する
- [ ] ＋（タスク追加）ボタンを開き、種別ドロップダウンからOFFにした種別が消えていることを確認する
- [ ] 種別を再度ONに戻すと、ドロップダウンに復帰することを確認する
- [ ] `npx tsc --noEmit` が通ること（確認済み）

## スクリーンショット
（UI挙動の修正のためなし）

## 備考
設定保存時の再読み込み（`refreshSettings` → `setSettings` → `filteredTaskListsForCurrentTab` 再計算）は元から正しく動作していたため、変更はこの1関数のみです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)