### PR TITLE
fix: 設定保存を Cookie から localStorage へ移行し種別タブ追加の不具合を解消

### DIFF
--- a/src/app/components/SettingsModal.tsx
+++ b/src/app/components/SettingsModal.tsx
@@ -40,10 +40,12 @@ export default function SettingsModal({
   const [showNewFilterSetForm, setShowNewFilterSetForm] = useState(false);
   const [showQRCode, setShowQRCode] = useState(false);
   const [qrUrl, setQrUrl] = useState("");
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isOpen) {
       setSettings(getSettings());
+      setSaveError(null);
     }
   }, [isOpen]);
 
@@ -54,11 +56,35 @@ export default function SettingsModal({
   }, [isOpen, onRefreshTaskLists]);
 
   const handleSave = () => {
+    // 「+ 新しいフィルターセットを追加」フォームに入力したまま（インラインの「追加」未押下で）
+    // 保存した場合に取りこぼさないよう、入力途中のセットを保存対象に取り込む
+    let filterSets = settings.taskFilterSets;
+    if (showNewFilterSetForm && newFilterSetName.trim()) {
+      const allCategories: Record<string, boolean> = {};
+      availableCategories.forEach(category => {
+        allCategories[category] = true;
+      });
+      filterSets = [...filterSets, createTaskFilterSet(newFilterSetName.trim(), allCategories)];
+    }
+
     const settingsToSave = {
       ...settings,
-      taskFilterSets: settings.taskFilterSets.map(set => ({ ...set, name: set.name.trim() })),
+      taskFilterSets: filterSets.map(set => ({ ...set, name: set.name.trim() })),
     };
-    saveSettings(settingsToSave);
+
+    const saved = saveSettings(settingsToSave);
+    if (!saved) {
+      // 保存失敗時は閉じずにエラー表示し、入力内容を保持する
+      setSaveError(
+        "設定を保存できませんでした。ブラウザのストレージ容量が不足している可能性があります。不要なフィルターセットを削除してから再度お試しください。"
+      );
+      return;
+    }
+
+    setSettings(settingsToSave);
+    setNewFilterSetName('');
+    setShowNewFilterSetForm(false);
+    setSaveError(null);
     onClose();
   };
 
@@ -70,6 +96,7 @@ export default function SettingsModal({
   const handleCancel = () => {
     setShowNewFilterSetForm(false);
     setNewFilterSetName('');
+    setSaveError(null);
     onClose();
   };
 
@@ -416,6 +443,14 @@ export default function SettingsModal({
           </div>
 
         </div>
+
+        {saveError && (
+          <div className="px-4 pt-2">
+            <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">
+              {saveError}
+            </p>
+          </div>
+        )}
 
         <div className="flex justify-end gap-3 p-4 border-t border-gray-200">
           <button

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -44,8 +44,9 @@ const DEFAULT_SETTINGS: AppSettings = {
   selectedFilterSetId: 'default',
 };
 
-const SETTINGS_COOKIE_NAME = "todo-app-settings";
-const SELECTED_TAB_COOKIE_NAME = "todo-app-selected-tab";
+// 設定は localStorage に保存する（容量 約5〜10MB）。
+// 旧バージョンでは同名の Cookie に保存していたため、初回読み込み時に移行する。
+const SETTINGS_STORAGE_KEY = "todo-app-settings";
 
 export function getSettings(): AppSettings {
   if (typeof window === "undefined") {
@@ -53,7 +54,7 @@ export function getSettings(): AppSettings {
   }
 
   try {
-    const stored = getCookie(SETTINGS_COOKIE_NAME);
+    const stored = readStoredSettings();
     if (stored) {
       const parsed = JSON.parse(stored);
       // visibleLists を深くマージすることで、新しいキーがデフォルト値で自動的に補完される
@@ -78,16 +79,28 @@ export function getSettings(): AppSettings {
   return DEFAULT_SETTINGS;
 }
 
-export function saveSettings(settings: AppSettings): void {
+/**
+ * 設定を localStorage に保存する。
+ * 書き込み後に読み戻して照合し、容量超過（QuotaExceededError）などの
+ * 失敗を検知できるよう、成否を boolean で返す。
+ */
+export function saveSettings(settings: AppSettings): boolean {
   if (typeof window === "undefined") {
-    return;
+    return false;
   }
 
   try {
     const value = JSON.stringify(settings);
-    setCookie(SETTINGS_COOKIE_NAME, value, 365);
+    localStorage.setItem(SETTINGS_STORAGE_KEY, value);
+    // 保存検証: 書き込んだ値が実際に読み戻せるか確認する
+    if (localStorage.getItem(SETTINGS_STORAGE_KEY) !== value) {
+      console.error("設定の保存検証に失敗しました（保存値と読み戻し値が不一致）");
+      return false;
+    }
+    return true;
   } catch (error) {
     console.error("設定の保存に失敗しました:", error);
+    return false;
   }
 }
 
@@ -122,7 +135,37 @@ export function updateCategoriesFromTasks(tasks: { listTitle: string }[]): void 
   }
 }
 
-function getCookie(name: string): string | null {
+/**
+ * 設定の生文字列を取得する。localStorage を正とし、
+ * localStorage が空で旧 Cookie が残っている場合のみ、一度だけ localStorage へ移行する。
+ */
+function readStoredSettings(): string | null {
+  let value: string | null = null;
+  try {
+    value = localStorage.getItem(SETTINGS_STORAGE_KEY);
+  } catch {
+    value = null;
+  }
+  if (value !== null) {
+    return value;
+  }
+
+  // 旧バージョンの Cookie から移行（生 JSON 文字列として保存されている）
+  const legacy = getLegacyCookie(SETTINGS_STORAGE_KEY);
+  if (legacy !== null) {
+    try {
+      localStorage.setItem(SETTINGS_STORAGE_KEY, legacy);
+    } catch {
+      // 容量超過などで移行できなくても、今回読み込む値としては legacy を使う
+    }
+    deleteLegacyCookie(SETTINGS_STORAGE_KEY);
+    return legacy;
+  }
+
+  return null;
+}
+
+function getLegacyCookie(name: string): string | null {
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
   if (parts.length === 2) {
@@ -131,10 +174,8 @@ function getCookie(name: string): string | null {
   return null;
 }
 
-function setCookie(name: string, value: string, days: number): void {
-  const expires = new Date();
-  expires.setTime(expires.getTime() + (days * 24 * 60 * 60 * 1000));
-  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/`;
+function deleteLegacyCookie(name: string): void {
+  document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
 }
 
 // フィルターセット管理のヘルパー関数


### PR DESCRIPTION
## 関連仕様Issue
- なし（バグ修正のため仕様Issueなし）

## 実装内容
設定画面でフィルターセット（メイン画面の「種別」タブ）を追加・保存しても、メイン画面に新しいタブが反映されない不具合を修正する。

**原因:** 設定を約4KB上限の **Cookie**（`todo-app-settings`）に保存していたため、フィルターセット追加で `categories`（日本語キー）がセット数×カテゴリ数で蓄積して容量超過すると、`document.cookie` への書き込みが**例外なく黙殺**され、保存されないまま「成功」扱いになっていた。

**対応:**
- 保存先を **localStorage**（容量 約5〜10MB）へ移行。Key は `todo-app-settings` を流用し、`AppSettings` 全体を生JSON文字列で格納。旧 Cookie が残るユーザーは初回読み込み時に**一度だけ自動移行**（コピー後に旧 Cookie を削除）するため設定は失われない。
- `saveSettings` の戻り値を `void → boolean` に変更。書き込み後に**読み戻して照合**し、`QuotaExceededError` も捕捉して失敗を検知（サイレント失敗の根絶）。
- 設定モーダルで、インライン「追加」未押下のまま「保存」した場合も**入力途中のフィルターセットを保存対象に取り込む**。保存失敗時はモーダルを閉じずに**エラー表示**し入力を保持。

## 変更ファイル
- `src/lib/settings.ts` — Cookie→localStorage 移行、旧Cookieからの一度きり移行（`readStoredSettings`）、`saveSettings` の保存検証＆boolean返却、未使用の `SELECTED_TAB_COOKIE_NAME` 削除
- `src/app/components/SettingsModal.tsx` — `handleSave` の入力途中フラッシュ、保存失敗時のエラー表示UI

## テスト手順
- [ ] `npx tsc --noEmit` が通る（確認済み: exit 0）
- [ ] ログイン後、設定画面でフィルターセットを複数追加→保存→メイン画面のタブに即時反映される
- [ ] 旧 `todo-app-settings` Cookie がある状態で初回ロードし、localStorage へ移行され旧Cookieが消える
- [ ] フォームに名前入力後、インライン「追加」を押さず「保存」しても新セットが保存される
- [ ] DevTools で localStorage 容量を疑似的に超過させ、保存失敗時にエラー文が表示される
- [ ] QRコード設定同期（`settingsQR`）が従来どおり動作する

## スクリーンショット
（UI追加は保存失敗時のエラー表示のみ。通常フローの見た目変更なし）

## 備考
- `settingsQR.ts`（QR共有）はURLパラメータベースでCookie非依存のため無改修。
- サーバー側（SSR・API route・auth）は設定Cookieを参照していないため影響なし。
- eslint の既存警告 `set-state-in-effect` 等は origin/main にも存在する既存事象で、本PRでは新規に混入していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)