### PR TITLE
fix: 新規タスク種別がカスタムフィルターセットに自動混入する不具合を修正

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -125,10 +125,13 @@ export function updateCategoriesFromTasks(tasks: { listTitle: string }[]): void 
   });
 
   // フィルターセットにも新しいカテゴリーを追加
+  // デフォルト（ALL）セットは新しい種別も自動表示するが、
+  // ユーザーが手動で絞り込んだカスタムセットには自動的に含めない（OFFで追加）。
+  // そうしないと、後から作られた無関係な種別がカスタムグループの選択肢に紛れ込んでしまう。
   settings.taskFilterSets.forEach(filterSet => {
     tasks.forEach(task => {
       if (task.listTitle && !(task.listTitle in filterSet.categories)) {
-        filterSet.categories[task.listTitle] = true;
+        filterSet.categories[task.listTitle] = filterSet.isDefault;
         needsUpdate = true;
       }
     });


### PR DESCRIPTION
## 関連仕様Issue
- Closes #（該当なし。ユーザー報告のバグ修正）

## 実装内容
タスク追加ボタン押下時のタスク種別プルダウンに、現在選択中のフィルターセット（種別タブ/グループ）に含まれていないはずの種別が選択肢として表示される不具合を修正。

原因は `updateCategoriesFromTasks`（src/lib/settings.ts）が、新しいタスク種別を検知した際に、デフォルト（ALL）以外のカスタムフィルターセットにも一律 `true`（表示ON）で自動追加していたこと。ユーザーが手動で絞り込んだグループに、後から作られた無関係な種別が自動的に混入していた。

## 変更ファイル
- src/lib/settings.ts: 新規カテゴリー自動追加時、デフォルトセットのみ true、カスタムセットは false で追加するよう変更

## テスト手順
- [ ] 複数のタスク種別（Google Tasksリスト）を持つ状態でカスタムフィルターセットを作成し、一部の種別のみチェックONにする
- [ ] 新しいタスク種別（リスト）を作成しタスクを追加する
- [ ] 元のカスタムフィルターセットのタブに切り替え、タスク追加モーダルの「タスク種別」プルダウンに新しい種別が含まれていないことを確認する
- [ ] `npx tsc --noEmit` / `npx eslint` がパスすることを確認済み

## 備考
Google OAuthログインが必要なため、ブラウザでの実機確認は未実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)